### PR TITLE
Add function to find the closest git repo given a file path

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -7,4 +7,5 @@ module.exports = {
   InstallFlow: require('./elements/install-flow.js'),
   StateController: require('./state-controller.js'),
   Telemetry: require('../ext/telemetry/atom-telemetry.js'),
+  uitls: require('./utils.js'),
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,3 +1,6 @@
+var fs = require('fs');
+var path = require('path');
+
 function bindEnterToClick(ele, btn) {
   ele.addEventListener('keypress', (e) => {
     if (e.keyCode === 13) {
@@ -61,9 +64,38 @@ function handleResponseData(resp, callback) {
   });
 }
 
+// Finds the closest Git repo by searching up the file paths.
+// This function throws and error if the filePath given does not
+// exist.
+function findClosestGitRepo(filePath) {
+  var isDir = (p) => {
+    return fs.lstatSync(p).isDirectory();
+  };
+  var isRepo = (p) => {
+    var n = path.join(p, '.git');
+    try {
+      fs.accessSync(n, fs.W_OK | fs.R_OK);
+      return true;
+    } catch (e) {
+      return false;
+    }
+  };
+  if (!isDir(filePath)) {
+    filePath = path.dirname(filePath);
+  }
+  if (isRepo(filePath)) {
+    return filePath;
+  }
+  if (filePath.length === 1) {
+    return null;
+  }
+  return findClosestGitRepo(path.dirname(filePath));
+}
+
 module.exports = {
   bindEnterToClick: bindEnterToClick,
   parseSetCookies: parseSetCookies,
   dumpCookies: dumpCookies,
   handleResponseData: handleResponseData,
+  findClosestGitRepo: findClosestGitRepo,
 };

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kite-installer",
   "main": "./lib/index.js",
-  "version": "0.0.24",
+  "version": "0.0.25",
   "description": "Javascript library to install and manage Kite",
   "author": "Daniel Hung",
   "keywords": [],


### PR DESCRIPTION
Adds `utils.findClosestGitRepo` which given a file path, searches for the first git repo found searching up the path tree. `utils` is now also exported in `index.js` for use by other libraries