### PR TITLE
Use curl to download Kite

### DIFF
--- a/lib/installer.js
+++ b/lib/installer.js
@@ -85,7 +85,7 @@ var Installer = class {
   writeAndRun(callback) {
     Tracker.trackEvent("saving to disk");
     this.installPromise.then(() => {
-      StateController.writeDownloadedKite(this.installOpts).then(() => {
+      StateController.writeKite(this.installOpts).then(() => {
         Tracker.trackEvent("installed successfully");
         StateController.runKiteAndWait(30, Installer.INTERVAL).then(() => {
           Tracker.trackEvent("app started successfully");

--- a/lib/installer.js
+++ b/lib/installer.js
@@ -38,12 +38,12 @@ var Installer = class {
     this.authTimerID = null;
     this.whitelistTimerID = null;
 
-    this.installOpts = {
-      deferWrite: true,
+    this.opts = {
+      install: false,
       onDownload: () => {
         this.flow.installStep.progress.addMarker(20, 4000, 10);
       },
-      onWrite: () => {
+      onInstallStart: () => {
         this.flow.installStep.progress.addMarker(30, 1000, 10);
       },
       onMount: () => {
@@ -75,17 +75,17 @@ var Installer = class {
   install() {
     Tracker.trackEvent("enabled kite");
     this.flow.showCreateAccount(this.parsedEmail);
-    this.installPromise = StateController.installKiteRelease(this.installOpts);
+    this.installPromise = StateController.downloadKiteRelease(this.opts);
     this.installPromise.catch((err) => {
       Tracker.trackEvent("error downloading to memory", { error: err });
       console.error("error installing kite:", err);
     });
   }
 
-  writeAndRun(callback) {
+  installAndRun(callback) {
     Tracker.trackEvent("saving to disk");
     this.installPromise.then(() => {
-      StateController.writeKite(this.installOpts).then(() => {
+      StateController.installKite(this.opts).then(() => {
         Tracker.trackEvent("installed successfully");
         StateController.runKiteAndWait(30, Installer.INTERVAL).then(() => {
           Tracker.trackEvent("app started successfully");
@@ -126,7 +126,7 @@ var Installer = class {
             email: data.email,
             path: this.path,
           });
-          this.writeAndRun(() => this.attemptAuthenticate());
+          this.installAndRun(() => this.attemptAuthenticate());
           break;
         case 409:
           Tracker.trackEvent("email exists showing login");
@@ -175,7 +175,7 @@ var Installer = class {
             this.onAuthenticate();
           }
           this.flow.showWhitelist({ path: this.path });
-          this.writeAndRun(() => this.attemptAuthenticate());
+          this.installAndRun(() => this.attemptAuthenticate());
           break;
         case 400:
         case 401:

--- a/lib/state-controller.js
+++ b/lib/state-controller.js
@@ -27,7 +27,7 @@ var StateController = {
     darwin: 'https://alpha.kite.com/release/dls/mac/current',
   },
   APPS_PATH: '/Applications/',
-  KITE_DMG_PATH: '/Applications/Kite.dmg',
+  KITE_DMG_PATH: '/tmp/Kite.dmg',
   KITE_VOLUME_PATH: '/Volumes/Kite/',
   KITE_APP_PATH: {
     mounted: '/Volumes/Kite/Kite.app',
@@ -77,33 +77,27 @@ var StateController = {
 
   installKite: function(url, opts) {
     opts = opts || {};
-    var handle = (resp, resolve, reject) => {
-      if (resp.statusCode === 303) {
-        this.installKite(resp.headers.location, opts).then(resolve, reject);
-        return;
-      }
-      if (resp.statusCode !== 200) {
-        reject({ type: 'bad_status', data: resp.statusCode });
-        return;
-      }
+    var handle = (resolve, reject) => {
       if (typeof(opts.onDownload) === 'function') {
         opts.onDownload();
       }
       if (!opts.deferWrite) {
-        this.writeKite(resp, opts).then(resolve, reject);
+        this.writeKite(opts).then(resolve, reject);
       } else {
-        this.downloadedStream = new PassThrough();
-        resp.pipe(this.downloadedStream);
         resolve();
       }
     };
 
     return new Promise((resolve, reject) => {
       this.canInstallKite().then(() => {
-        https.get(url, (resp) => {
-          handle(resp, resolve, reject);
-        }).on('error', (e) => {
-          reject({ type: 'http_error', data: e });
+        var proc = child_process.spawn(
+          'curl', ['-L', url, '--output', this.KITE_DMG_PATH]);
+        proc.on('close', (code) => {
+          if (code) {
+            reject({ type: 'curl_error', data: proc.stderr });
+          } else {
+            handle(resolve, reject);
+          }
         });
       }, (err) => {
         reject(err);
@@ -111,13 +105,9 @@ var StateController = {
     });
   },
 
-  writeKite: function(stream, opts) {
+  writeKite: function(opts) {
     opts = opts || {};
     return new Promise((resolve, reject) => {
-      if (!stream) {
-        reject({ type: 'bad_read_stream', data: stream });
-      }
-
       var rm = () => {
         var proc = child_process.spawn('rm', [this.KITE_DMG_PATH]);
         proc.on('close', (code) => {
@@ -161,20 +151,11 @@ var StateController = {
         });
       };
 
-      var file = fs.createWriteStream(this.KITE_DMG_PATH);
-      file.on('finish', () => {
-        if (typeof(opts.onWrite) === 'function') {
-          opts.onWrite();
-        }
-        mount();
-      });
-      stream.pipe(file);
+      if (typeof(opts.onWrite) === 'function') {
+        opts.onWrite();
+      }
+      mount();
     });
-  },
-
-  writeDownloadedKite: function(opts) {
-    opts = opts || {};
-    return this.writeKite(this.downloadedStream, opts);
   },
 
   isKiteRunning: function() {

--- a/lib/state-controller.js
+++ b/lib/state-controller.js
@@ -75,14 +75,14 @@ var StateController = {
     });
   },
 
-  installKite: function(url, opts) {
+  downloadKite: function(url, opts) {
     opts = opts || {};
     var handle = (resolve, reject) => {
       if (typeof(opts.onDownload) === 'function') {
         opts.onDownload();
       }
-      if (!opts.deferWrite) {
-        this.writeKite(opts).then(resolve, reject);
+      if (opts.install) {
+        this.installKite(opts).then(resolve, reject);
       } else {
         resolve();
       }
@@ -105,12 +105,16 @@ var StateController = {
     });
   },
 
-  writeKite: function(opts) {
+  installKite: function(opts) {
     opts = opts || {};
     return new Promise((resolve, reject) => {
       var rm = () => {
         var proc = child_process.spawn('rm', [this.KITE_DMG_PATH]);
         proc.on('close', (code) => {
+          if (code) {
+            reject({ type: 'rm_error', data: proc.stderr });
+            return;
+          }
           if (typeof(opts.onRemove) === 'function') {
             opts.onRemove();
           }
@@ -122,6 +126,10 @@ var StateController = {
         var proc = child_process.spawn(
           'hdiutil', ['detach', this.KITE_VOLUME_PATH]);
         proc.on('close', (code) => {
+          if (code) {
+            reject({ type: 'unmount_error', data: proc.stderr });
+            return;
+          }
           if (typeof(opts.onUnmount) === 'function') {
             opts.onUnmount();
           }
@@ -133,6 +141,10 @@ var StateController = {
         var proc = child_process.spawn(
           'cp', ['-r', this.KITE_APP_PATH.mounted, this.APPS_PATH]);
         proc.on('close', (code) => {
+          if (code) {
+            reject({ type: 'cp_error', data: proc.stderr });
+            return;
+          }
           if (typeof(opts.onCopy) === 'function') {
             opts.onCopy();
           }
@@ -144,6 +156,10 @@ var StateController = {
         var proc = child_process.spawn(
           'hdiutil', ['attach', '-nobrowse', this.KITE_DMG_PATH]);
         proc.on('close', (code) => {
+          if (code) {
+            reject({ type: 'mount_error', data: proc.stderr });
+            return;
+          }
           if (typeof(opts.onMount) === 'function') {
             opts.onMount();
           }
@@ -151,8 +167,8 @@ var StateController = {
         });
       };
 
-      if (typeof(opts.onWrite) === 'function') {
-        opts.onWrite();
+      if (typeof(opts.onInstallStart) === 'function') {
+        opts.onInstallStart();
       }
       mount();
     });
@@ -469,9 +485,9 @@ var StateController = {
     return this.RELEASE_URLS[os.platform()];
   },
 
-  installKiteRelease: function(opts) {
+  downloadKiteRelease: function(opts) {
     opts = opts || {};
-    return this.installKite(this.releaseURL, opts);
+    return this.downloadKite(this.releaseURL, opts);
   },
 };
 

--- a/package.json
+++ b/package.json
@@ -1,14 +1,11 @@
 {
   "name": "kite-installer",
-  "main": "./examples/main.js",
-  "version": "0.0.0",
-  "description": "A simple plugin to install Kite from Atom",
+  "main": "./lib/index.js",
+  "version": "0.5.0",
+  "description": "Javascript library to install and manage Kite",
   "author": "Daniel Hung",
   "keywords": [],
   "license": "MIT",
-  "engines": {
-    "atom": ">=1.0.0 <2.0.0"
-  },
   "dependencies": {
     "mixpanel": "^0.5.0"
   }

--- a/package.json
+++ b/package.json
@@ -1,11 +1,14 @@
 {
   "name": "kite-installer",
-  "main": "./lib/index.js",
-  "version": "0.4.8",
-  "description": "Javascript library to install and manage Kite",
+  "main": "./examples/main.js",
+  "version": "0.0.0",
+  "description": "A simple plugin to install Kite from Atom",
   "author": "Daniel Hung",
   "keywords": [],
   "license": "MIT",
+  "engines": {
+    "atom": ">=1.0.0 <2.0.0"
+  },
   "dependencies": {
     "mixpanel": "^0.5.0"
   }


### PR DESCRIPTION
* Uses `curl` to download Kite to address the connectivity issues we were seeing before
* Writes the `.dmg` file to `/tmp` instead of `/Applications`
* Renames some functions for clairty
  * `download` means the `/tmp/Kite.dmg` has been fetched
  * `install` means the mounting, copying, etc has been completed
* Calls `reject()` in the intermediary `install` steps to log them in Mixpanel