### PR TITLE
Prepare multi os support

### DIFF
--- a/lib/account-manager.js
+++ b/lib/account-manager.js
@@ -2,16 +2,22 @@
 
 const os = require('os');
 const fs = require('fs');
-const path = require('path');
 const querystring = require('querystring');
 
 const Client = require('./client.js');
 const utils = require('./utils.js');
+const {NO_SUPPORT, SUPPORTS} = require('./constants');
 
 const AccountManager = {
-  SESSION_FILE_PATH: path.resolve(os.homedir(), '.kite/session.json'),
-
   client: null,
+
+  get SESSION_FILE_PATH() {
+    return this.support.sessionFilePath;
+  },
+
+  get support() {
+    return SUPPORTS[os.platform()] || NO_SUPPORT;
+  },
 
   initClient(hostname, port, ssl) {
     this.client = new Client(hostname, port, '', ssl);

--- a/lib/account-manager.js
+++ b/lib/account-manager.js
@@ -1,12 +1,11 @@
 'use strict';
 
-const os = require('os');
 const fs = require('fs');
 const querystring = require('querystring');
 
 const Client = require('./client.js');
 const utils = require('./utils.js');
-const {NO_SUPPORT, SUPPORTS} = require('./constants');
+const {SUPPORTS} = require('./constants');
 
 const AccountManager = {
   client: null,
@@ -16,7 +15,7 @@ const AccountManager = {
   },
 
   get support() {
-    return SUPPORTS[os.platform()] || NO_SUPPORT;
+    return SUPPORTS.getSupport();
   },
 
   initClient(hostname, port, ssl) {

--- a/lib/client.js
+++ b/lib/client.js
@@ -1,20 +1,18 @@
 'use strict';
 
-const os = require('os');
 const fs = require('fs');
-const path = require('path');
 
 const http = require('http');
 const https = require('https');
 
 const KiteError = require('./kite-error');
-const utils = require('./utils.js');
-const LOCAL_TOKEN_PATH = path.resolve(os.homedir(), '.kite/localtoken');
+const utils = require('./utils');
+const {SUPPORTS} = require('./constants');
 
 let lastLocaltoken, lastLocaltokenMtime;
 
 function loadLocaltokenMtime() {
-  fs.lstatSync(LOCAL_TOKEN_PATH).mtime;
+  fs.lstatSync(SUPPORTS.getSupport().localTokenPath).mtime;
 }
 function loadLocaltoken() {
   const tokenMtime = loadLocaltokenMtime();
@@ -22,7 +20,7 @@ function loadLocaltoken() {
   if (lastLocaltoken && tokenMtime === lastLocaltokenMtime) {
     return lastLocaltoken;
   } else {
-    lastLocaltoken = String(fs.readFileSync(LOCAL_TOKEN_PATH));
+    lastLocaltoken = String(fs.readFileSync(SUPPORTS.getSupport().localTokenPath));
     lastLocaltokenMtime = tokenMtime;
     return lastLocaltoken;
   }
@@ -30,7 +28,7 @@ function loadLocaltoken() {
 
 module.exports = class Client {
   get LOCAL_TOKEN() {
-    return fs.existsSync(LOCAL_TOKEN_PATH)
+    return fs.existsSync(SUPPORTS.getSupport().localTokenPath)
       ? loadLocaltoken()
       : undefined;
   }

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -1,3 +1,5 @@
+const os = require('os');
+
 module.exports = {
   DEBUG: true,
 
@@ -11,14 +13,13 @@ module.exports = {
     WHITELISTED: 6,
   },
 
-  get NO_SUPPORT() {
-    return require('./support/no-support');
-  },
-
-  get SUPPORTS() {
-    return {
-      darwin: require('./support/osx'),
-      win32: require('./support/windows'),
-    };
+  SUPPORTS: {
+    getSupport() {
+      switch (os.platform()) {
+        case 'darwin': return require('./support/osx');
+        case 'win32': return require('./support/windows');
+        default: return require('./support/no-support');
+      }
+    },
   },
 };

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -10,4 +10,15 @@ module.exports = {
     AUTHENTICATED: 5,
     WHITELISTED: 6,
   },
+
+  get NO_SUPPORT() {
+    return require('./support/no-support');
+  },
+
+  get SUPPORTS() {
+    return {
+      darwin: require('./support/osx'),
+      win32: require('./support/windows'),
+    };
+  },
 };

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -1,3 +1,13 @@
 module.exports = {
   DEBUG: true,
+
+  STATES: {
+    UNSUPPORTED: 0,
+    UNINSTALLED: 1,
+    INSTALLED: 2,
+    RUNNING: 3,
+    REACHABLE: 4,
+    AUTHENTICATED: 5,
+    WHITELISTED: 6,
+  },
 };

--- a/lib/decision-maker.js
+++ b/lib/decision-maker.js
@@ -2,9 +2,10 @@
 
 const os = require('os');
 
-const Client = require('./client.js');
-const KiteError = require('./kite-error.js');
-const utils = require('./utils.js');
+const Client = require('./client');
+const StateController = require('./state-controller');
+const KiteError = require('./kite-error');
+const utils = require('./utils');
 
 class DecisionMaker {
   constructor(editor, plugin) {
@@ -24,6 +25,8 @@ class DecisionMaker {
       editor: this.editor.name,
       os: os.platform(),
       osVersion: os.release(),
+      arch: os.arch(),
+      admin: StateController.isAdmin(),
       plugin: this.plugin.name,
     });
 

--- a/lib/decision-maker.js
+++ b/lib/decision-maker.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const fs = require('fs');
 const os = require('os');
 
 const Client = require('./client');
@@ -28,6 +29,8 @@ class DecisionMaker {
       arch: os.arch(),
       admin: StateController.isAdmin(),
       plugin: this.plugin.name,
+      kiteInstalled: fs.existsSync(StateController.installPath),
+      atomPluginInstalled: atom.packages.getLoadedPackage('kite') != null,
     });
 
     return this.client.request({

--- a/lib/state-controller.js
+++ b/lib/state-controller.js
@@ -78,16 +78,7 @@ const StateController = {
     const req = https.request(this.releaseURL);
     req.end();
 
-    return utils.promisifyRequest(req)
-    .then(resp => {
-      if (resp.statusCode === 303) {
-        const req = https.request(resp.headers.location);
-        req.end();
-        return utils.promisifyRequest(req);
-      } else {
-        throw new KiteError('bad_status', resp.statusCode);
-      }
-    })
+    return utils.followRedirections(req)
     .then(resp => {
       if (progress) {
         const total = parseInt(resp.headers['content-length'], 10);

--- a/lib/state-controller.js
+++ b/lib/state-controller.js
@@ -42,6 +42,10 @@ const StateController = {
     });
   },
 
+  isAdmin() {
+    return this.support.isAdmin();
+  },
+
   isKiteSupported() {
     return this.support.isKiteSupported()
       ? Promise.resolve()

--- a/lib/state-controller.js
+++ b/lib/state-controller.js
@@ -8,6 +8,7 @@ const https = require('https');
 const Client = require('./client.js');
 const KiteError = require('./kite-error');
 const utils = require('./utils.js');
+const NO_SUPPORT = require('./support/no-support');
 const {STATES} = require('./constants');
 
 const StateController = {
@@ -15,26 +16,25 @@ const StateController = {
 
   STATES,
 
-  RELEASE_URLS: {
-    darwin: 'https://alpha.kite.com/release/dls/mac/current',
+  SUPPORTS: {
+    darwin: require('./support/osx'),
   },
-  APPS_PATH: '/Applications/',
-  KITE_DMG_PATH: '/tmp/Kite.dmg',
-  KITE_VOLUME_PATH: '/Volumes/Kite/',
-  KITE_APP_PATH: {
-    mounted: '/Volumes/Kite/Kite.app',
-    installed: '/Applications/Kite.app',
+
+  get support() {
+    return this.SUPPORTS[os.platform()] || NO_SUPPORT;
   },
-  KITE_SIDEBAR_PATH: '/Applications/Kite.app/Contents/MacOS/KiteSidebar.app',
-  KITE_BUNDLE_ID: 'com.kite.Kite',
 
   get releaseURL() {
-    return this.RELEASE_URLS[os.platform()];
+    return this.support.releaseURL;
+  },
+
+  get downloadPath() {
+    return this.support.downloadPath;
   },
 
   handleState(path) {
     return this.isPathWhitelisted(path)
-    .then(() => this.STATES.WHITELISTED)
+    .then(() => STATES.WHITELISTED)
     .catch(err => {
       if (err.type !== 'bad_state') { throw err; }
       return err.data;
@@ -42,25 +42,24 @@ const StateController = {
   },
 
   isKiteSupported() {
-    return os.platform() === 'darwin' && os.release() >= '10.10.0'
+    return this.support.isKiteSupported()
       ? Promise.resolve()
-      : Promise.reject({ type: 'bad_state', data: this.STATES.UNSUPPORTED });
+      : Promise.reject({
+        type: 'bad_state',
+        data: STATES.UNSUPPORTED,
+      });
   },
 
   isKiteInstalled() {
     return this.isKiteSupported()
-    .then(() => {
-      if (!fs.existsSync(this.KITE_APP_PATH.installed)) {
-        throw new KiteError('bad_state', this.STATES.UNINSTALLED);
-      }
-    });
+    .then(() => this.support.isKiteInstalled());
   },
 
   canInstallKite() {
     return this.isKiteSupported()
     .then(() =>
       utils.reversePromise(this.isKiteInstalled(),
-        new KiteError('bad_state', this.STATES.INSTALLED)));
+        new KiteError('bad_state', STATES.INSTALLED)));
   },
 
   downloadKiteRelease(opts) {
@@ -85,7 +84,6 @@ const StateController = {
         const req = https.request(resp.headers.location);
         req.end();
         return utils.promisifyRequest(req);
-
       } else {
         throw new KiteError('bad_status', resp.statusCode);
       }
@@ -102,63 +100,29 @@ const StateController = {
       }
 
       return utils.promisifyStream(
-        resp.pipe(fs.createWriteStream(this.KITE_DMG_PATH)));
+        resp.pipe(fs.createWriteStream(this.downloadPath)));
     });
   },
 
   installKite(opts) {
-    opts = opts || {};
-
-    utils.guardCall(opts.onInstallStart);
-    return utils.spawnPromise('hdiutil', [
-      'attach', '-nobrowse', this.KITE_DMG_PATH,
-    ], 'mount_error')
-    .then(() => utils.guardCall(opts.onMount))
-    .then(() => utils.spawnPromise('cp', [
-      '-r', this.KITE_APP_PATH.mounted, this.APPS_PATH,
-    ], 'cp_error'))
-    .then(() => utils.guardCall(opts.onCopy))
-    .then(() => utils.spawnPromise('hdiutil', [
-      'detach', this.KITE_VOLUME_PATH,
-    ], 'unmount_error'))
-    .then(() => utils.guardCall(opts.onUnmount))
-    .then(() => utils.spawnPromise('rm', [
-      this.KITE_DMG_PATH,
-    ], 'rm_error'))
-    .then(() => utils.guardCall(opts.onRemove));
+    return this.support.installKite(opts);
   },
 
   isKiteRunning() {
     return this.isKiteInstalled()
-    .then(() =>
-      utils.spawnPromise('/bin/ps', [
-        '-axco', 'command',
-      ], {
-        encoding: 'utf8',
-      }, 'unmount_error'))
-    .then(stdout => {
-      const procs = stdout.split('\n');
-      if (procs.indexOf('Kite') === -1) {
-        throw new KiteError('bad_state', this.STATES.INSTALLED);
-      }
-    });
+    .then(() => this.support.isKiteRunning());
   },
 
   canRunKite() {
     return this.isKiteInstalled()
     .then(() =>
       utils.reversePromise(this.isKiteRunning(),
-        new KiteError('bad_state', this.STATES.RUNNING)));
+        new KiteError('bad_state', STATES.RUNNING)));
   },
 
   runKite() {
     return this.canRunKite()
-    .then(() =>
-      utils.spawnPromise('defaults', [
-        'write', 'com.kite.Kite', 'shouldReopenSidebar', '0',
-      ]))
-    .then(() =>
-      utils.spawnPromise('open', ['-a', this.KITE_APP_PATH.installed]));
+    .then(() => this.support.runKite());
   },
 
   isKiteReachable() {
@@ -168,7 +132,7 @@ const StateController = {
         path: '/system',
         method: 'GET',
       }).catch(err => {
-        throw new KiteError('bad_state', this.STATES.RUNNING);
+        throw new KiteError('bad_state', STATES.RUNNING);
       }));
   },
 
@@ -195,11 +159,11 @@ const StateController = {
           return utils.handleResponseData(resp)
           .then((data) => {
             if (data !== 'authenticated') {
-              throw new KiteError('bad_state', this.STATES.REACHABLE);
+              throw new KiteError('bad_state', STATES.REACHABLE);
             }
           });
         case 401:
-          throw new KiteError('bad_state', this.STATES.REACHABLE);
+          throw new KiteError('bad_state', STATES.REACHABLE);
         default:
           throw new KiteError('bad_status', resp.statusCode);
       }
@@ -280,10 +244,9 @@ const StateController = {
       return utils.handleResponseData(resp);
     })
     .then(data => {
-      console.log(data);
       const dirs = utils.parseJSON(data, []);
       if (!dirs.some(dir => path.indexOf(dir) === 0)) {
-        throw new KiteError('bad_state', this.STATES.AUTHENTICATED);
+        throw new KiteError('bad_state', STATES.AUTHENTICATED);
       }
     });
   },
@@ -291,7 +254,7 @@ const StateController = {
   canWhitelistPath(path) {
     return this.isUserAuthenticated()
     .then(() => utils.reversePromise(this.isPathWhitelisted(path),
-      new KiteError('bad_state', this.STATES.WHITELISTED)));
+      new KiteError('bad_state', STATES.WHITELISTED)));
   },
 
   whitelistPath(path) {

--- a/lib/state-controller.js
+++ b/lib/state-controller.js
@@ -8,21 +8,15 @@ const https = require('https');
 const Client = require('./client.js');
 const KiteError = require('./kite-error');
 const utils = require('./utils.js');
-const NO_SUPPORT = require('./support/no-support');
-const {STATES} = require('./constants');
+const {STATES, NO_SUPPORT, SUPPORTS} = require('./constants');
 
 const StateController = {
   client: new Client('127.0.0.1', 46624, '', false),
 
   STATES,
 
-  SUPPORTS: {
-    darwin: require('./support/osx'),
-    win32: require('./support/windows'),
-  },
-
   get support() {
-    return this.SUPPORTS[os.platform()] || NO_SUPPORT;
+    return SUPPORTS[os.platform()] || NO_SUPPORT;
   },
 
   get releaseURL() {

--- a/lib/state-controller.js
+++ b/lib/state-controller.js
@@ -1,14 +1,13 @@
 'use strict';
 
 const fs = require('fs');
-const os = require('os');
 const querystring = require('querystring');
 const https = require('https');
 
 const Client = require('./client.js');
 const KiteError = require('./kite-error');
 const utils = require('./utils.js');
-const {STATES, NO_SUPPORT, SUPPORTS} = require('./constants');
+const {STATES, SUPPORTS} = require('./constants');
 
 const StateController = {
   client: new Client('127.0.0.1', 46624, '', false),
@@ -16,7 +15,7 @@ const StateController = {
   STATES,
 
   get support() {
-    return SUPPORTS[os.platform()] || NO_SUPPORT;
+    return SUPPORTS.getSupport();
   },
 
   get releaseURL() {

--- a/lib/state-controller.js
+++ b/lib/state-controller.js
@@ -77,12 +77,12 @@ const StateController = {
   downloadKite(url, opts) {
     opts = opts || {};
     return this.canInstallKite()
-    .then(() => this.streamKiteDownload())
+    .then(() => this.streamKiteDownload(opts.onDownloadProgress))
     .then(() => utils.guardCall(opts.onDownload))
     .then(() => opts.install && this.installKite(opts));
   },
 
-  streamKiteDownload() {
+  streamKiteDownload(progress) {
     const req = https.request(this.releaseURL);
     req.end();
 
@@ -98,13 +98,15 @@ const StateController = {
       }
     })
     .then(resp => {
-      const total = parseInt(resp.headers['content-length'], 10);
-      let length = 0;
+      if (progress) {
+        const total = parseInt(resp.headers['content-length'], 10);
+        let length = 0;
 
-      resp.on('data', chunk => {
-        length += chunk.length;
-        console.log(Math.round(length / total * 100) + '%');
-      });
+        resp.on('data', chunk => {
+          length += chunk.length;
+          progress(length, total, length / total);
+        });
+      }
 
       return utils.promisifyStream(
         resp.pipe(fs.createWriteStream(this.KITE_DMG_PATH)));

--- a/lib/state-controller.js
+++ b/lib/state-controller.js
@@ -3,6 +3,7 @@
 const fs = require('fs');
 const os = require('os');
 const querystring = require('querystring');
+const https = require('https');
 
 const Client = require('./client.js');
 const KiteError = require('./kite-error');
@@ -76,11 +77,38 @@ const StateController = {
   downloadKite(url, opts) {
     opts = opts || {};
     return this.canInstallKite()
-    .then(() => utils.spawnPromise('curl', [
-      '-L', url, '--output', this.KITE_DMG_PATH,
-    ], 'curl_error'))
+    .then(() => this.streamKiteDownload())
     .then(() => utils.guardCall(opts.onDownload))
     .then(() => opts.install && this.installKite(opts));
+  },
+
+  streamKiteDownload() {
+    const req = https.request(this.releaseURL);
+    req.end();
+
+    return utils.promisifyRequest(req)
+    .then(resp => {
+      if (resp.statusCode === 303) {
+        const req = https.request(resp.headers.location);
+        req.end();
+        return utils.promisifyRequest(req);
+
+      } else {
+        throw new KiteError('bad_status', resp.statusCode);
+      }
+    })
+    .then(resp => {
+      const total = parseInt(resp.headers['content-length'], 10);
+      let length = 0;
+
+      resp.on('data', chunk => {
+        length += chunk.length;
+        console.log(Math.round(length / total * 100) + '%');
+      });
+
+      return utils.promisifyStream(
+        resp.pipe(fs.createWriteStream(this.KITE_DMG_PATH)));
+    });
   },
 
   installKite(opts) {

--- a/lib/state-controller.js
+++ b/lib/state-controller.js
@@ -33,6 +33,10 @@ const StateController = {
     return this.support.downloadPath;
   },
 
+  get installPath() {
+    return this.support.installPath;
+  },
+
   handleState(path) {
     return this.isPathWhitelisted(path)
     .then(() => STATES.WHITELISTED)

--- a/lib/state-controller.js
+++ b/lib/state-controller.js
@@ -8,19 +8,12 @@ const https = require('https');
 const Client = require('./client.js');
 const KiteError = require('./kite-error');
 const utils = require('./utils.js');
+const {STATES} = require('./constants');
 
 const StateController = {
   client: new Client('127.0.0.1', 46624, '', false),
 
-  STATES: {
-    UNSUPPORTED: 0,
-    UNINSTALLED: 1,
-    INSTALLED: 2,
-    RUNNING: 3,
-    REACHABLE: 4,
-    AUTHENTICATED: 5,
-    WHITELISTED: 6,
-  },
+  STATES,
 
   RELEASE_URLS: {
     darwin: 'https://alpha.kite.com/release/dls/mac/current',

--- a/lib/state-controller.js
+++ b/lib/state-controller.js
@@ -18,6 +18,7 @@ const StateController = {
 
   SUPPORTS: {
     darwin: require('./support/osx'),
+    win32: require('./support/windows'),
   },
 
   get support() {

--- a/lib/support/no-support.js
+++ b/lib/support/no-support.js
@@ -1,0 +1,38 @@
+const KiteError = require('../kite-error');
+
+const {STATES} = require('../constants');
+
+module.exports = {
+  get releaseURL() {
+    return null;
+  },
+
+  get downloadPath() {
+    return null;
+  },
+
+  isKiteSupported() {
+    return false;
+  },
+
+  isKiteInstalled() {
+    return this.notSupported();
+  },
+
+  installKite(opts) {
+    return this.notSupported();
+  },
+
+  isKiteRunning() {
+    return this.notSupported();
+  },
+
+  runKite() {
+    return this.notSupported();
+  },
+
+  notSupported() {
+    return Promise.reject(
+      new KiteError('bad_state', STATES.UNSUPPORTED));
+  },
+};

--- a/lib/support/no-support.js
+++ b/lib/support/no-support.js
@@ -15,6 +15,10 @@ module.exports = {
     return null;
   },
 
+  get sessionFilePath() {
+    return null;
+  },
+
   isAdmin() {
     return false;
   },

--- a/lib/support/no-support.js
+++ b/lib/support/no-support.js
@@ -11,6 +11,10 @@ module.exports = {
     return null;
   },
 
+  isAdmin() {
+    return false;
+  },
+
   isKiteSupported() {
     return false;
   },

--- a/lib/support/no-support.js
+++ b/lib/support/no-support.js
@@ -11,6 +11,10 @@ module.exports = {
     return null;
   },
 
+  get installPath() {
+    return null;
+  },
+
   isAdmin() {
     return false;
   },

--- a/lib/support/no-support.js
+++ b/lib/support/no-support.js
@@ -19,6 +19,10 @@ module.exports = {
     return null;
   },
 
+  get localTokenPath() {
+    return null;
+  },
+
   isAdmin() {
     return false;
   },

--- a/lib/support/osx.js
+++ b/lib/support/osx.js
@@ -1,0 +1,83 @@
+const os = require('os');
+const fs = require('fs');
+const utils = require('../utils.js');
+const KiteError = require('../kite-error');
+const {STATES} = require('../constants');
+
+const OSXSupport = {
+  RELEASE_URL: 'https://alpha.kite.com/release/dls/mac/current',
+  APPS_PATH: '/Applications/',
+  KITE_DMG_PATH: '/tmp/Kite.dmg',
+  KITE_VOLUME_PATH: '/Volumes/Kite/',
+  KITE_APP_PATH: {
+    mounted: '/Volumes/Kite/Kite.app',
+    installed: '/Applications/Kite.app',
+  },
+  KITE_SIDEBAR_PATH: '/Applications/Kite.app/Contents/MacOS/KiteSidebar.app',
+  KITE_BUNDLE_ID: 'com.kite.Kite',
+
+  get releaseURL() {
+    return this.RELEASE_URL;
+  },
+
+  get downloadPath() {
+    return this.KITE_DMG_PATH;
+  },
+
+  isKiteSupported() {
+    return os.release() >= '10.10.0';
+  },
+
+  isKiteInstalled() {
+    return fs.existsSync(this.KITE_APP_PATH.installed)
+      ? Promise.resolve()
+      : Promise.reject(
+          new KiteError('bad_state', STATES.UNINSTALLED));
+  },
+
+  installKite(opts) {
+    opts = opts || {};
+
+    utils.guardCall(opts.onInstallStart);
+    return utils.spawnPromise('hdiutil', [
+      'attach', '-nobrowse', this.KITE_DMG_PATH,
+    ], 'mount_error')
+    .then(() => utils.guardCall(opts.onMount))
+    .then(() => utils.spawnPromise('cp', [
+      '-r', this.KITE_APP_PATH.mounted, this.APPS_PATH,
+    ], 'cp_error'))
+    .then(() => utils.guardCall(opts.onCopy))
+    .then(() => utils.spawnPromise('hdiutil', [
+      'detach', this.KITE_VOLUME_PATH,
+    ], 'unmount_error'))
+    .then(() => utils.guardCall(opts.onUnmount))
+    .then(() => utils.spawnPromise('rm', [
+      this.KITE_DMG_PATH,
+    ], 'rm_error'))
+    .then(() => utils.guardCall(opts.onRemove));
+  },
+
+  isKiteRunning() {
+    return utils.spawnPromise('/bin/ps', [
+      '-axco', 'command',
+    ], {
+      encoding: 'utf8',
+    }, 'unmount_error')
+    .then(stdout => {
+      const procs = stdout.split('\n');
+      if (procs.indexOf('Kite') === -1) {
+        throw new KiteError('bad_state', STATES.INSTALLED);
+      }
+    });
+  },
+
+  runKite() {
+    return utils.spawnPromise('defaults', [
+      'write', 'com.kite.Kite', 'shouldReopenSidebar', '0',
+    ])
+    .then(() =>
+      utils.spawnPromise('open', ['-a', this.KITE_APP_PATH.installed]));
+  },
+};
+
+module.exports = OSXSupport;

--- a/lib/support/osx.js
+++ b/lib/support/osx.js
@@ -1,5 +1,6 @@
 const os = require('os');
 const fs = require('fs');
+const child_process = require('child_process');
 const utils = require('../utils.js');
 const KiteError = require('../kite-error');
 const {STATES} = require('../constants');
@@ -22,6 +23,21 @@ const OSXSupport = {
 
   get downloadPath() {
     return this.KITE_DMG_PATH;
+  },
+
+  isAdmin() {
+    try {
+      const user = String(child_process.execSync('whoami')).trim();
+      const adminUsers = String(child_process.execSync('dscacheutil -q group -a name admin'))
+      .split('\n')
+      .filter(l => /^users:/.test(l))[0]
+      .trim()
+      .replace(/users:\s+/, '')
+      .split(/\s/g);
+      return adminUsers.includes(user);
+    } catch (e) {
+      return false;
+    }
   },
 
   isKiteSupported() {

--- a/lib/support/osx.js
+++ b/lib/support/osx.js
@@ -18,6 +18,7 @@ const OSXSupport = {
   KITE_SIDEBAR_PATH: '/Applications/Kite.app/Contents/MacOS/KiteSidebar.app',
   KITE_BUNDLE_ID: 'com.kite.Kite',
   SESSION_FILE_PATH: path.join(os.homedir(), '.kite', 'session.json'),
+  LOCAL_TOKEN_PATH: path.join(os.homedir(), '.kite', 'localtoken'),
 
   get releaseURL() {
     return this.RELEASE_URL;
@@ -33,6 +34,10 @@ const OSXSupport = {
 
   get sessionFilePath() {
     return this.SESSION_FILE_PATH;
+  },
+
+  get localTokenPath() {
+    return this.LOCAL_TOKEN_PATH;
   },
 
   isAdmin() {

--- a/lib/support/osx.js
+++ b/lib/support/osx.js
@@ -51,8 +51,7 @@ const OSXSupport = {
   isKiteInstalled() {
     return fs.existsSync(this.KITE_APP_PATH.installed)
       ? Promise.resolve()
-      : Promise.reject(
-          new KiteError('bad_state', STATES.UNINSTALLED));
+      : Promise.reject(new KiteError('bad_state', STATES.UNINSTALLED));
   },
 
   installKite(opts) {
@@ -82,7 +81,7 @@ const OSXSupport = {
       '-axco', 'command',
     ], {
       encoding: 'utf8',
-    }, 'unmount_error')
+    }, 'ps_error')
     .then(stdout => {
       const procs = stdout.split('\n');
       if (procs.indexOf('Kite') === -1) {

--- a/lib/support/osx.js
+++ b/lib/support/osx.js
@@ -1,5 +1,6 @@
 const os = require('os');
 const fs = require('fs');
+const path = require('path');
 const child_process = require('child_process');
 const utils = require('../utils.js');
 const KiteError = require('../kite-error');
@@ -16,6 +17,7 @@ const OSXSupport = {
   },
   KITE_SIDEBAR_PATH: '/Applications/Kite.app/Contents/MacOS/KiteSidebar.app',
   KITE_BUNDLE_ID: 'com.kite.Kite',
+  SESSION_FILE_PATH: path.join(os.homedir(), '.kite', 'session.json'),
 
   get releaseURL() {
     return this.RELEASE_URL;
@@ -27,6 +29,10 @@ const OSXSupport = {
 
   get installPath() {
     return this.KITE_APP_PATH.installed;
+  },
+
+  get sessionFilePath() {
+    return this.SESSION_FILE_PATH;
   },
 
   isAdmin() {

--- a/lib/support/osx.js
+++ b/lib/support/osx.js
@@ -25,7 +25,7 @@ const OSXSupport = {
   },
 
   isKiteSupported() {
-    return os.release() >= '10.10.0';
+    return parseFloat(os.release()) >= 14;
   },
 
   isKiteInstalled() {

--- a/lib/support/osx.js
+++ b/lib/support/osx.js
@@ -25,6 +25,10 @@ const OSXSupport = {
     return this.KITE_DMG_PATH;
   },
 
+  get installPath() {
+    return this.KITE_APP_PATH.installed;
+  },
+
   isAdmin() {
     try {
       const user = String(child_process.execSync('whoami')).trim();

--- a/lib/support/windows.js
+++ b/lib/support/windows.js
@@ -10,12 +10,14 @@ const {STATES} = require('../constants');
 if (os.platform() !== 'win32') {
   process.env.TMP = os.tmpDir();
   process.env.ProgramW6432 = os.tmpDir();
+  process.env.LOCALAPPDATA = os.tmpDir();
 }
 
 const WindowsSupport = {
   RELEASE_URL: 'https://alpha.kite.com/release/dls/windows/current',
   KITE_INSTALLER_PATH: path.join(process.env.TMP, 'Kite.exe'),
   KITE_EXE_PATH: path.join(process.env.ProgramW6432, 'Kite', 'kited.exe'),
+  SESSION_FILE_PATH: path.join(process.env.LOCALAPPDATA, '.kite', 'session.json'),
 
   get releaseURL() {
     return this.RELEASE_URL;
@@ -27,6 +29,10 @@ const WindowsSupport = {
 
   get installPath() {
     return this.KITE_EXE_PATH;
+  },
+
+  get sessionFilePath() {
+    return this.SESSION_FILE_PATH;
   },
 
   isAdmin() {

--- a/lib/support/windows.js
+++ b/lib/support/windows.js
@@ -13,6 +13,10 @@ const WindowsSupport = {
     return null;
   },
 
+  get installPath() {
+    return null;
+  },
+
   isAdmin() {
     try {
       child_process.execSync('net session');

--- a/lib/support/windows.js
+++ b/lib/support/windows.js
@@ -23,7 +23,7 @@ const WindowsSupport = {
   },
 
   isKiteSupported() {
-    return parseFloat(os.release()) >= 6.1;
+    return parseFloat(os.release()) >= 6.1 && os.arch() === 'x64';
   },
 
   isKiteInstalled() {

--- a/lib/support/windows.js
+++ b/lib/support/windows.js
@@ -1,4 +1,5 @@
 const os = require('os');
+const child_process = require('child_process');
 const KiteError = require('../kite-error');
 
 const {STATES} = require('../constants');
@@ -10,6 +11,15 @@ const WindowsSupport = {
 
   get downloadPath() {
     return null;
+  },
+
+  isAdmin() {
+    try {
+      child_process.execSync('net session');
+      return true;
+    } catch (e) {
+      return false;
+    }
   },
 
   isKiteSupported() {

--- a/lib/support/windows.js
+++ b/lib/support/windows.js
@@ -7,12 +7,6 @@ const KiteError = require('../kite-error');
 
 const {STATES} = require('../constants');
 
-if (os.platform() !== 'win32') {
-  process.env.TMP = os.tmpDir();
-  process.env.ProgramW6432 = os.tmpDir();
-  process.env.LOCALAPPDATA = os.tmpDir();
-}
-
 const WindowsSupport = {
   RELEASE_URL: 'https://alpha.kite.com/release/dls/windows/current',
   KITE_INSTALLER_PATH: path.join(process.env.TMP, 'Kite.exe'),

--- a/lib/support/windows.js
+++ b/lib/support/windows.js
@@ -7,6 +7,11 @@ const KiteError = require('../kite-error');
 
 const {STATES} = require('../constants');
 
+if (os.platform() !== 'win32') {
+  process.env.TMP = os.tmpDir();
+  process.env.ProgramW6432 = os.tmpDir();
+}
+
 const WindowsSupport = {
   RELEASE_URL: 'https://alpha.kite.com/release/dls/windows/current',
   KITE_INSTALLER_PATH: path.join(process.env.TMP, 'Kite.exe'),

--- a/lib/support/windows.js
+++ b/lib/support/windows.js
@@ -54,9 +54,7 @@ const WindowsSupport = {
     utils.guardCall(opts.onInstallStart);
     return utils.spawnPromise(this.KITE_INSTALLER_PATH)
     .then(() => utils.guardCall(opts.onCopy))
-    .then(() => utils.spawnPromise('del', [
-      this.KITE_INSTALLER_PATH,
-    ], 'del_error'))
+    .then(() => fs.unlinkSync(this.KITE_INSTALLER_PATH))
     .then(() => utils.guardCall(opts.onRemove));
   },
 

--- a/lib/support/windows.js
+++ b/lib/support/windows.js
@@ -1,0 +1,41 @@
+const os = require('os');
+const KiteError = require('../kite-error');
+
+const {STATES} = require('../constants');
+
+const WindowsSupport = {
+  get releaseURL() {
+    return null;
+  },
+
+  get downloadPath() {
+    return null;
+  },
+
+  isKiteSupported() {
+    return parseFloat(os.release()) >= 6.1;
+  },
+
+  isKiteInstalled() {
+    return this.notSupported();
+  },
+
+  installKite(opts) {
+    return this.notSupported();
+  },
+
+  isKiteRunning() {
+    return this.notSupported();
+  },
+
+  runKite() {
+    return this.notSupported();
+  },
+
+  notSupported() {
+    return Promise.reject(
+      new KiteError('bad_state', STATES.UNSUPPORTED));
+  },
+};
+
+module.exports = WindowsSupport;

--- a/lib/support/windows.js
+++ b/lib/support/windows.js
@@ -12,6 +12,7 @@ const WindowsSupport = {
   KITE_INSTALLER_PATH: path.join(process.env.TMP, 'Kite.exe'),
   KITE_EXE_PATH: path.join(process.env.ProgramW6432, 'Kite', 'kited.exe'),
   SESSION_FILE_PATH: path.join(process.env.LOCALAPPDATA, '.kite', 'session.json'),
+  LOCAL_TOKEN_PATH: path.join(process.env.LOCALAPPDATA, '.kite', 'localtoken'),
 
   get releaseURL() {
     return this.RELEASE_URL;
@@ -27,6 +28,10 @@ const WindowsSupport = {
 
   get sessionFilePath() {
     return this.SESSION_FILE_PATH;
+  },
+
+  get localTokenPath() {
+    return this.LOCAL_TOKEN_PATH;
   },
 
   isAdmin() {

--- a/lib/support/windows.js
+++ b/lib/support/windows.js
@@ -35,6 +35,7 @@ const WindowsSupport = {
   },
 
   isKiteRunning() {
+    // use tasklist then search for kite exe
     return this.notSupported();
   },
 

--- a/lib/support/windows.js
+++ b/lib/support/windows.js
@@ -1,20 +1,27 @@
 const os = require('os');
+const fs = require('fs');
+const path = require('path');
 const child_process = require('child_process');
+const utils = require('../utils.js');
 const KiteError = require('../kite-error');
 
 const {STATES} = require('../constants');
 
 const WindowsSupport = {
+  RELEASE_URL: 'https://alpha.kite.com/release/dls/windows/current',
+  KITE_INSTALLER_PATH: path.join(process.env.TMP, 'Kite.exe'),
+  KITE_EXE_PATH: path.join(process.env.ProgramW6432, 'Kite', 'kited.exe'),
+
   get releaseURL() {
-    return null;
+    return this.RELEASE_URL;
   },
 
   get downloadPath() {
-    return null;
+    return this.KITE_INSTALLER_PATH;
   },
 
   get installPath() {
-    return null;
+    return this.KITE_EXE_PATH;
   },
 
   isAdmin() {
@@ -31,25 +38,35 @@ const WindowsSupport = {
   },
 
   isKiteInstalled() {
-    return this.notSupported();
+    return fs.existsSync(this.KITE_EXE_PATH)
+      ? Promise.resolve()
+      : Promise.reject(new KiteError('bad_state', STATES.UNINSTALLED));
   },
 
   installKite(opts) {
-    return this.notSupported();
+    opts = opts || {};
+
+    utils.guardCall(opts.onInstallStart);
+    return utils.spawnPromise(this.KITE_INSTALLER_PATH)
+    .then(() => utils.guardCall(opts.onCopy))
+    .then(() => utils.spawnPromise('del', [
+      this.KITE_INSTALLER_PATH,
+    ], 'del_error'))
+    .then(() => utils.guardCall(opts.onRemove));
   },
 
   isKiteRunning() {
-    // use tasklist then search for kite exe
-    return this.notSupported();
+    return utils.spawnPromise('tasklist', 'tasklist_error')
+    .then(stdout => {
+      const procs = stdout.split('\n');
+      if (procs.indexOf('kited.exe') === -1) {
+        throw new KiteError('bad_state', STATES.INSTALLED);
+      }
+    });
   },
 
   runKite() {
-    return this.notSupported();
-  },
-
-  notSupported() {
-    return Promise.reject(
-      new KiteError('bad_state', STATES.UNSUPPORTED));
+    return utils.spawnPromise(this.KITE_EXE_PATH);
   },
 };
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,8 +1,11 @@
 'use strict';
 
-var fs = require('fs');
-var path = require('path');
-var child_process = require('child_process');
+const fs = require('fs');
+const path = require('path');
+const http = require('http');
+const https = require('https');
+const child_process = require('child_process');
+const KiteError = require('./kite-error');
 
 function promisifyRequest(request) {
   return new Promise((resolve, reject) => {
@@ -15,6 +18,29 @@ function promisifyStream(stream) {
   return new Promise((resolve, reject) => {
     stream.on('finish', () => resolve());
     stream.on('error', err => reject(err));
+  });
+}
+
+function request(url) {
+  return url.indexOf('https://') === 0
+    ? https.request(url)
+    : http.request(url);
+}
+
+// Given a request this function will follow the redirection until a
+// code different that 303 is returned
+function followRedirections(req) {
+  return promisifyRequest(req)
+  .then(resp => {
+    if (resp.statusCode === 200) {
+      return resp;
+    } else if (resp.statusCode === 303) {
+      const req = request(resp.headers.location);
+      req.end();
+      return followRedirections(req);
+    } else {
+      throw new KiteError('bad_status', resp.statusCode);
+    }
   });
 }
 
@@ -204,4 +230,5 @@ module.exports = {
   parseJSON,
   promisifyRequest,
   promisifyStream,
+  followRedirections,
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -27,10 +27,14 @@ function request(url) {
     : http.request(url);
 }
 
+function   hasHeader(header, headers) {
+  return header in headers ? header : false;
+}
+
 function isRedirection(resp) {
   return resp.statusCode >= 300 &&
          resp.statusCode < 400 &&
-         resp.req.hasHeader('location', resp.headers);
+         hasHeader('location', resp.headers);
 }
 
 // Given a request this function will follow the redirection until a
@@ -41,7 +45,7 @@ function followRedirections(req) {
     if (resp.statusCode >= 200 && resp.statusCode < 300) {
       return resp;
     } else if (isRedirection(resp)) {
-      const location = resp.headers[resp.req.hasHeader('location', resp.headers)];
+      const location = resp.headers.location;
       const req = request(location);
       req.end();
       return followRedirections(req);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -27,15 +27,22 @@ function request(url) {
     : http.request(url);
 }
 
+function isRedirection(resp) {
+  return resp.statusCode >= 300 &&
+         resp.statusCode < 400 &&
+         resp.req.hasHeader('location', resp.headers);
+}
+
 // Given a request this function will follow the redirection until a
 // code different that 303 is returned
 function followRedirections(req) {
   return promisifyRequest(req)
   .then(resp => {
-    if (resp.statusCode === 200) {
+    if (resp.statusCode >= 200 && resp.statusCode < 300) {
       return resp;
-    } else if (resp.statusCode === 303) {
-      const req = request(resp.headers.location);
+    } else if (isRedirection(resp)) {
+      const location = resp.headers[resp.req.hasHeader('location', resp.headers)];
+      const req = request(location);
       req.end();
       return followRedirections(req);
     } else {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -4,6 +4,20 @@ var fs = require('fs');
 var path = require('path');
 var child_process = require('child_process');
 
+function promisifyRequest(request) {
+  return new Promise((resolve, reject) => {
+    request.on('response', resp => resolve(resp));
+    request.on('error', err => reject(err));
+  });
+}
+
+function promisifyStream(stream) {
+  return new Promise((resolve, reject) => {
+    stream.on('finish', () => resolve());
+    stream.on('error', err => reject(err));
+  });
+}
+
 function bindEnterToClick(ele, btn) {
   ele.addEventListener('keypress', (e) => {
     if (e.keyCode === 13) {
@@ -188,4 +202,6 @@ module.exports = {
   retryPromise,
   guardCall,
   parseJSON,
+  promisifyRequest,
+  promisifyStream,
 };

--- a/spec/spec-helpers.js
+++ b/spec/spec-helpers.js
@@ -1,3 +1,4 @@
+const os = require('os');
 const http = require('http');
 const https = require('https');
 const proc = require('child_process');
@@ -123,12 +124,22 @@ function fakeRequestMethod(resp) {
 function fakeKiteInstallPaths() {
   let safePaths;
   beforeEach(() => {
-    safePaths = OSXSupport.KITE_APP_PATH;
-    OSXSupport.KITE_APP_PATH = { installed: '/path/to/Kite.app' };
+    switch (os.platform()) {
+      case 'darwin':
+        safePaths = OSXSupport.KITE_APP_PATH;
+        OSXSupport.KITE_APP_PATH = {
+          installed: '/path/to/Kite.app',
+        };
+        break;
+    }
   });
 
   afterEach(() => {
-    OSXSupport.KITE_APP_PATH = safePaths;
+    switch (os.platform()) {
+      case 'darwin':
+        OSXSupport.KITE_APP_PATH = safePaths;
+        break;
+    }
   });
 }
 
@@ -147,7 +158,11 @@ function withKiteInstalled(block) {
     fakeKiteInstallPaths();
 
     beforeEach(() => {
-      OSXSupport.KITE_APP_PATH = { installed: __filename };
+      switch (os.platform()) {
+        case 'darwin':
+          OSXSupport.KITE_APP_PATH = { installed: __filename };
+          break;
+      }
     });
 
     block();
@@ -158,13 +173,17 @@ function withKiteRunning(block) {
   withKiteInstalled(() => {
     describe(', running', () => {
       beforeEach(() => {
-        fakeProcesses({
-          ls: (ps) => ps.stdout('kite'),
-          '/bin/ps': (ps) => {
-            ps.stdout('Kite');
-            return 0;
-          },
-        });
+        switch (os.platform()) {
+          case 'darwin':
+            fakeProcesses({
+              ls: (ps) => ps.stdout('kite'),
+              '/bin/ps': (ps) => {
+                ps.stdout('Kite');
+                return 0;
+              },
+            });
+            break;
+        }
       });
 
       block();
@@ -176,14 +195,18 @@ function withKiteNotRunning(block) {
   withKiteInstalled(() => {
     describe(', not running', () => {
       beforeEach(() => {
-        fakeProcesses({
-          '/bin/ps': (ps) => {
-            ps.stdout('');
-            return 0;
-          },
-          defaults: () => 0,
-          open: () => 0,
-        });
+        switch (os.platform()) {
+          case 'darwin':
+            fakeProcesses({
+              '/bin/ps': (ps) => {
+                ps.stdout('');
+                return 0;
+              },
+              defaults: () => 0,
+              open: () => 0,
+            });
+            break;
+        }
       });
 
       block();

--- a/spec/spec-helpers.js
+++ b/spec/spec-helpers.js
@@ -134,9 +134,6 @@ function fakeRequestMethod(resp) {
         }
       },
       write(data) {},
-      hasHeader(header, headers) {
-        return header in headers ? header : false;
-      },
       setTimeout(timeout, callback) {
         if (resp == null) { callback({}); }
       },

--- a/spec/spec-helpers.js
+++ b/spec/spec-helpers.js
@@ -1,9 +1,18 @@
+
+let OSXSupport, WindowsSupport;
+
 const os = require('os');
 const http = require('http');
 const https = require('https');
 const proc = require('child_process');
-const OSXSupport = require('../lib/support/osx');
-const WindowsSupport = require('../lib/support/windows');
+
+// This ensure that the env variables required by the
+// windows support object are available even on another platform.
+if (os.platform() !== 'win32') {
+  process.env.TMP = os.tmpDir();
+  process.env.ProgramW6432 = os.tmpDir();
+  process.env.LOCALAPPDATA = os.tmpDir();
+}
 
 function fakeStdStream() {
   let streamCallback;
@@ -142,12 +151,18 @@ function fakeKiteInstallPaths() {
   beforeEach(() => {
     switch (os.platform()) {
       case 'darwin':
+        if (!OSXSupport) {
+          OSXSupport = require('../lib/support/osx');
+        }
         safePaths = OSXSupport.KITE_APP_PATH;
         OSXSupport.KITE_APP_PATH = {
           installed: '/path/to/Kite.app',
         };
         break;
       case 'win32':
+        if (!WindowsSupport) {
+          WindowsSupport = require('../lib/support/windows');
+        }
         safePaths = WindowsSupport.KITE_EXE_PATH;
         WindowsSupport.KITE_EXE_PATH = 'C:\\Windows\\Kite.exe';
         break;
@@ -183,9 +198,15 @@ function withKiteInstalled(block) {
     beforeEach(() => {
       switch (os.platform()) {
         case 'darwin':
+          if (!OSXSupport) {
+            OSXSupport = require('../lib/support/osx');
+          }
           OSXSupport.KITE_APP_PATH = { installed: __filename };
           break;
         case 'win32':
+          if (!WindowsSupport) {
+            WindowsSupport = require('../lib/support/windows');
+          }
           WindowsSupport.KITE_EXE_PATH = __filename;
           break;
       }

--- a/spec/spec-helpers.js
+++ b/spec/spec-helpers.js
@@ -1,7 +1,7 @@
 const http = require('http');
 const https = require('https');
 const proc = require('child_process');
-const StateController = require('../lib/state-controller');
+const OSXSupport = require('../lib/support/osx');
 
 function fakeStdStream() {
   let streamCallback;
@@ -123,12 +123,12 @@ function fakeRequestMethod(resp) {
 function fakeKiteInstallPaths() {
   let safePaths;
   beforeEach(() => {
-    safePaths = StateController.KITE_APP_PATH;
-    StateController.KITE_APP_PATH = { installed: '/path/to/Kite.app' };
+    safePaths = OSXSupport.KITE_APP_PATH;
+    OSXSupport.KITE_APP_PATH = { installed: '/path/to/Kite.app' };
   });
 
   afterEach(() => {
-    StateController.KITE_APP_PATH = safePaths;
+    OSXSupport.KITE_APP_PATH = safePaths;
   });
 }
 
@@ -147,7 +147,7 @@ function withKiteInstalled(block) {
     fakeKiteInstallPaths();
 
     beforeEach(() => {
-      StateController.KITE_APP_PATH = { installed: __filename };
+      OSXSupport.KITE_APP_PATH = { installed: __filename };
     });
 
     block();

--- a/spec/state-controller-spec.js
+++ b/spec/state-controller-spec.js
@@ -4,12 +4,10 @@
 const os = require('os');
 const http = require('http');
 const https = require('https');
-const proc = require('child_process');
 const StateController = require('../lib/state-controller');
-const OSXSupport = require('../lib/support/osx');
 
 const {
-  fakeProcesses, fakeRequestMethod, fakeKiteInstallPaths, fakeResponse,
+  fakeRequestMethod, fakeKiteInstallPaths, fakeResponse,
   withKiteInstalled, withKiteRunning, withKiteNotRunning,
   withKiteReachable, withKiteNotReachable,
   withKiteNotAuthenticated, withKiteWhitelistedPaths,
@@ -94,40 +92,6 @@ describe('StateController', () => {
     });
   });
 
-  describe('.isKiteSupported()', () => {
-    it('returns a resolved promise for darwin platform', () => {
-      waitsForPromise(() => StateController.isKiteSupported());
-    });
-
-    describe('for another platform', () => {
-      beforeEach(() => {
-        spyOn(os, 'platform').andReturn('linux');
-      });
-
-      it('returns a rejected promise', () => {
-        waitsForPromise({
-          shouldReject: true,
-        }, () => StateController.isKiteSupported());
-      });
-    });
-  });
-
-  describe('.isKiteInstalled()', () => {
-    withKiteInstalled(() => {
-      it('returns a resolved promise', () => {
-        waitsForPromise(() => StateController.isKiteInstalled());
-      });
-    });
-
-    describe('when there is no file at the given path', () => {
-      it('returns a rejected promise', () => {
-        waitsForPromise({
-          shouldReject: true,
-        }, () => StateController.isKiteInstalled());
-      });
-    });
-  });
-
   describe('.canInstallKite()', () => {
     withKiteInstalled(() => {
       it('returns a rejected promise', () => {
@@ -140,110 +104,6 @@ describe('StateController', () => {
     describe('when kite is not installed', () => {
       it('returns a resolved promise', () => {
         waitsForPromise(() => StateController.canInstallKite());
-      });
-    });
-  });
-
-  describe('.installKite()', () => {
-    describe('when every command succeeds', () => {
-      beforeEach(() => {
-        fakeProcesses({
-          hdiutil: () => 0,
-          cp: () => 0,
-          rm: () => 0,
-        });
-      });
-
-      it('returns a resolved promise', () => {
-        const options = {
-          onInstallStart: jasmine.createSpy(),
-          onMount: jasmine.createSpy(),
-          onCopy: jasmine.createSpy(),
-          onUnmount: jasmine.createSpy(),
-          onRemove: jasmine.createSpy(),
-        };
-
-        waitsForPromise(() => StateController.installKite(options));
-        runs(() => {
-          expect(proc.spawn).toHaveBeenCalledWith('hdiutil', [
-            'attach', '-nobrowse',
-            OSXSupport.KITE_DMG_PATH,
-          ]);
-          expect(proc.spawn).toHaveBeenCalledWith('cp', [
-            '-r',
-            OSXSupport.KITE_APP_PATH.mounted,
-            OSXSupport.APPS_PATH,
-          ]);
-          expect(proc.spawn).toHaveBeenCalledWith('hdiutil', [
-            'detach',
-            OSXSupport.KITE_VOLUME_PATH,
-          ]);
-          expect(proc.spawn).toHaveBeenCalledWith('rm', [
-            OSXSupport.KITE_DMG_PATH,
-          ]);
-
-          expect(options.onInstallStart).toHaveBeenCalled();
-          expect(options.onMount).toHaveBeenCalled();
-          expect(options.onCopy).toHaveBeenCalled();
-          expect(options.onUnmount).toHaveBeenCalled();
-          expect(options.onRemove).toHaveBeenCalled();
-        });
-      });
-    });
-
-    describe('when mounting the archive fails', () => {
-      beforeEach(() => {
-        fakeProcesses({
-          hdiutil: () => 1,
-          cp: () => 0,
-          rm: () => 0,
-        });
-      });
-
-      it('returns a rejected promise', () => {
-        waitsForPromise({shouldReject: true}, () => StateController.installKite());
-      });
-    });
-
-    describe('when copying the archive content fails', () => {
-      beforeEach(() => {
-        fakeProcesses({
-          hdiutil: () => 0,
-          cp: () => 1,
-          rm: () => 0,
-        });
-      });
-
-      it('returns a rejected promise', () => {
-        waitsForPromise({shouldReject: true}, () => StateController.installKite());
-      });
-    });
-
-    describe('when unmounting the archive fails', () => {
-      beforeEach(() => {
-        fakeProcesses({
-          hdiutil: (ps, [command]) => command === 'attach' ? 0 : 1,
-          cp: () => 0,
-          rm: () => 0,
-        });
-      });
-
-      it('returns a rejected promise', () => {
-        waitsForPromise({shouldReject: true}, () => StateController.installKite());
-      });
-    });
-
-    describe('when removing the downloaded archive fails', () => {
-      beforeEach(() => {
-        fakeProcesses({
-          hdiutil: () => 0,
-          cp: () => 0,
-          rm: () => 1,
-        });
-      });
-
-      it('returns a rejected promise', () => {
-        waitsForPromise({shouldReject: true}, () => StateController.installKite());
       });
     });
   });
@@ -270,58 +130,7 @@ describe('StateController', () => {
         o => fakeResponse(200, 'foo'),
       ],
     ], () => {
-      describe('when the curl command succeeds', () => {
-        beforeEach(() => {
-          fakeProcesses({
-            hdiutil: () => 0,
-            cp: () => 0,
-            rm: () => 0,
-          });
-        });
-
-        describe('with the install option', () => {
-          it('returns a promise resolved after the install', () => {
-            const options = {
-              install: true,
-              onDownload: jasmine.createSpy(),
-              onInstallStart: jasmine.createSpy(),
-              onMount: jasmine.createSpy(),
-              onCopy: jasmine.createSpy(),
-              onUnmount: jasmine.createSpy(),
-              onRemove: jasmine.createSpy(),
-            };
-            const url = 'http://kite.com/download';
-
-            waitsForPromise(() => StateController.downloadKite(url, options));
-            runs(() => {
-              expect(https.request).toHaveBeenCalledWith('https://download.kite.com');
-              expect(proc.spawn).toHaveBeenCalledWith('hdiutil', [
-                'attach', '-nobrowse',
-                OSXSupport.KITE_DMG_PATH,
-              ]);
-              expect(proc.spawn).toHaveBeenCalledWith('cp', [
-                '-r',
-                OSXSupport.KITE_APP_PATH.mounted,
-                OSXSupport.APPS_PATH,
-              ]);
-              expect(proc.spawn).toHaveBeenCalledWith('hdiutil', [
-                'detach',
-                OSXSupport.KITE_VOLUME_PATH,
-              ]);
-              expect(proc.spawn).toHaveBeenCalledWith('rm', [
-                OSXSupport.KITE_DMG_PATH,
-              ]);
-
-              expect(options.onDownload).toHaveBeenCalled();
-              expect(options.onInstallStart).toHaveBeenCalled();
-              expect(options.onMount).toHaveBeenCalled();
-              expect(options.onCopy).toHaveBeenCalled();
-              expect(options.onUnmount).toHaveBeenCalled();
-              expect(options.onRemove).toHaveBeenCalled();
-            });
-          });
-        });
-
+      describe('when the download succeeds', () => {
         describe('without the install option', () => {
           beforeEach(() => {
             spyOn(StateController, 'installKite');
@@ -337,99 +146,6 @@ describe('StateController', () => {
 
               expect(StateController.installKite).not.toHaveBeenCalled();
             });
-          });
-        });
-      });
-    });
-  });
-
-  describe('.isKiteRunning()', () => {
-    describe('when kite is not installed', () => {
-      it('returns a rejected promise', () => {
-        waitsForPromise({shouldReject: true}, () => StateController.isKiteRunning());
-      });
-    });
-
-    withKiteInstalled(() => {
-      describe('but not running', () => {
-        beforeEach(() => {
-          fakeProcesses({
-            '/bin/ps': (ps) => {
-              ps.stdout('');
-              return 0;
-            },
-          });
-        });
-
-        it('returns a rejected promise', () => {
-          waitsForPromise({shouldReject: true}, () => StateController.isKiteRunning());
-        });
-      });
-
-      withKiteRunning(() => {
-        it('returns a resolved promise', () => {
-          waitsForPromise(() => StateController.isKiteRunning());
-        });
-      });
-    });
-  });
-
-  describe('.canRunKite()', () => {
-    describe('when kite is not installed', () => {
-      it('returns a rejected function', () => {
-        waitsForPromise({shouldReject: true}, () => StateController.canRunKite());
-      });
-    });
-
-    withKiteInstalled(() => {
-      describe('but not running', () => {
-        beforeEach(() => {
-          fakeProcesses({
-            '/bin/ps': (ps) => {
-              ps.stdout('');
-              return 0;
-            },
-          });
-        });
-
-        it('returns a resolved promise', () => {
-          waitsForPromise(() => StateController.canRunKite());
-        });
-      });
-
-      withKiteRunning(() => {
-        it('returns a rejected function', () => {
-          waitsForPromise({shouldReject: true}, () => StateController.canRunKite());
-        });
-      });
-    });
-  });
-
-  describe('.runKite()', () => {
-    describe('when kite is not installed', () => {
-      it('returns a rejected function', () => {
-        waitsForPromise({shouldReject: true}, () => StateController.runKite());
-      });
-    });
-
-    withKiteInstalled(() => {
-      withKiteRunning(() => {
-        it('returns a rejected function', () => {
-          waitsForPromise({shouldReject: true}, () => StateController.runKite());
-        });
-      });
-
-      withKiteNotRunning(() => {
-        it('returns a resolved promise', () => {
-          waitsForPromise(() => StateController.runKite());
-          runs(() => {
-            expect(proc.spawn).toHaveBeenCalledWith('defaults', [
-              'write', 'com.kite.Kite', 'shouldReopenSidebar', '0',
-            ]);
-
-            expect(proc.spawn).toHaveBeenCalledWith('open', [
-              '-a', OSXSupport.KITE_APP_PATH.installed,
-            ]);
           });
         });
       });
@@ -494,7 +210,6 @@ describe('StateController', () => {
       });
     });
   });
-
 
   describe('.isUserAuthenticated()', () => {
     withKiteRunning(() => {

--- a/spec/state-controller-spec.js
+++ b/spec/state-controller-spec.js
@@ -6,6 +6,7 @@ const http = require('http');
 const https = require('https');
 const proc = require('child_process');
 const StateController = require('../lib/state-controller');
+const OSXSupport = require('../lib/support/osx');
 
 const {
   fakeProcesses, fakeRequestMethod, fakeKiteInstallPaths, fakeResponse,
@@ -166,19 +167,19 @@ describe('StateController', () => {
         runs(() => {
           expect(proc.spawn).toHaveBeenCalledWith('hdiutil', [
             'attach', '-nobrowse',
-            StateController.KITE_DMG_PATH,
+            OSXSupport.KITE_DMG_PATH,
           ]);
           expect(proc.spawn).toHaveBeenCalledWith('cp', [
             '-r',
-            StateController.KITE_APP_PATH.mounted,
-            StateController.APPS_PATH,
+            OSXSupport.KITE_APP_PATH.mounted,
+            OSXSupport.APPS_PATH,
           ]);
           expect(proc.spawn).toHaveBeenCalledWith('hdiutil', [
             'detach',
-            StateController.KITE_VOLUME_PATH,
+            OSXSupport.KITE_VOLUME_PATH,
           ]);
           expect(proc.spawn).toHaveBeenCalledWith('rm', [
-            StateController.KITE_DMG_PATH,
+            OSXSupport.KITE_DMG_PATH,
           ]);
 
           expect(options.onInstallStart).toHaveBeenCalled();
@@ -296,19 +297,19 @@ describe('StateController', () => {
               expect(https.request).toHaveBeenCalledWith('https://download.kite.com');
               expect(proc.spawn).toHaveBeenCalledWith('hdiutil', [
                 'attach', '-nobrowse',
-                StateController.KITE_DMG_PATH,
+                OSXSupport.KITE_DMG_PATH,
               ]);
               expect(proc.spawn).toHaveBeenCalledWith('cp', [
                 '-r',
-                StateController.KITE_APP_PATH.mounted,
-                StateController.APPS_PATH,
+                OSXSupport.KITE_APP_PATH.mounted,
+                OSXSupport.APPS_PATH,
               ]);
               expect(proc.spawn).toHaveBeenCalledWith('hdiutil', [
                 'detach',
-                StateController.KITE_VOLUME_PATH,
+                OSXSupport.KITE_VOLUME_PATH,
               ]);
               expect(proc.spawn).toHaveBeenCalledWith('rm', [
-                StateController.KITE_DMG_PATH,
+                OSXSupport.KITE_DMG_PATH,
               ]);
 
               expect(options.onDownload).toHaveBeenCalled();
@@ -427,7 +428,7 @@ describe('StateController', () => {
             ]);
 
             expect(proc.spawn).toHaveBeenCalledWith('open', [
-              '-a', StateController.KITE_APP_PATH.installed,
+              '-a', OSXSupport.KITE_APP_PATH.installed,
             ]);
           });
         });

--- a/spec/support/no-support-spec.js
+++ b/spec/support/no-support-spec.js
@@ -1,0 +1,67 @@
+'use strict';
+
+const os = require('os');
+const StateController = require('../../lib/state-controller');
+
+describe('StateController - No Support', () => {
+  beforeEach(() => {
+    spyOn(os, 'platform').andReturn('wtf!');
+  });
+
+  describe('.isKiteSupported()', () => {
+    it('returns a rejected promise', () => {
+      waitsForPromise({
+        shouldReject: true,
+      }, () => StateController.isKiteSupported());
+    });
+  });
+
+  describe('.isKiteInstalled()', () => {
+    it('returns a rejected promise', () => {
+      waitsForPromise({
+        shouldReject: true,
+      }, () => StateController.isKiteInstalled());
+    });
+  });
+
+  describe('.installKite()', () => {
+    it('returns a rejected promise', () => {
+      waitsForPromise({
+        shouldReject: true,
+      }, () => StateController.installKite());
+    });
+  });
+
+  describe('.downloadKite()', () => {
+    it('returns a rejected promise', () => {
+      waitsForPromise({
+        shouldReject: true,
+      }, () => StateController.downloadKite());
+    });
+  });
+
+  describe('.isKiteRunning()', () => {
+    it('returns a rejected promise', () => {
+      waitsForPromise({
+        shouldReject: true,
+      }, () => StateController.isKiteRunning());
+    });
+  });
+
+  describe('.canRunKite()', () => {
+    it('returns a rejected promise', () => {
+      waitsForPromise({
+        shouldReject: true,
+      }, () => StateController.canRunKite());
+    });
+  });
+
+  describe('.runKite()', () => {
+    it('returns a rejected promise', () => {
+      waitsForPromise({
+        shouldReject: true,
+      }, () => StateController.runKite());
+    });
+  });
+
+});

--- a/spec/support/osx-spec.js
+++ b/spec/support/osx-spec.js
@@ -21,7 +21,7 @@ describe('StateController - OSX Support', () => {
   fakeKiteInstallPaths();
 
   describe('.isKiteSupported()', () => {
-    it('returns a resolved promise for darwin platform', () => {
+    it('returns a resolved promise', () => {
       waitsForPromise(() => StateController.isKiteSupported());
     });
   });

--- a/spec/support/osx-spec.js
+++ b/spec/support/osx-spec.js
@@ -24,6 +24,16 @@ describe('StateController - OSX Support', () => {
     it('returns a resolved promise', () => {
       waitsForPromise(() => StateController.isKiteSupported());
     });
+
+    describe('when the os release is below 10.10', () => {
+      beforeEach(() => {
+        spyOn(os, 'release').andReturn('13.0.0');
+      });
+
+      it('returns a rejected promise', () => {
+        waitsForPromise({shouldReject: true}, () => StateController.isKiteSupported());
+      });
+    });
   });
 
   describe('.isKiteInstalled()', () => {

--- a/spec/support/osx-spec.js
+++ b/spec/support/osx-spec.js
@@ -16,6 +16,7 @@ const {
 describe('StateController - OSX Support', () => {
   beforeEach(() => {
     spyOn(os, 'platform').andReturn('darwin');
+    spyOn(os, 'release').andReturn('14.0.0');
   });
 
   fakeKiteInstallPaths();
@@ -27,7 +28,7 @@ describe('StateController - OSX Support', () => {
 
     describe('when the os release is below 10.10', () => {
       beforeEach(() => {
-        spyOn(os, 'release').andReturn('13.0.0');
+        os.release.andReturn('13.0.0');
       });
 
       it('returns a rejected promise', () => {

--- a/spec/support/osx-spec.js
+++ b/spec/support/osx-spec.js
@@ -260,26 +260,15 @@ describe('StateController - OSX Support', () => {
       });
     });
 
-    withKiteInstalled(() => {
-      describe('but not running', () => {
-        beforeEach(() => {
-          fakeProcesses({
-            '/bin/ps': (ps) => {
-              ps.stdout('');
-              return 0;
-            },
-          });
-        });
-
-        it('returns a resolved promise', () => {
-          waitsForPromise(() => StateController.canRunKite());
-        });
+    withKiteNotRunning(() => {
+      it('returns a resolved promise', () => {
+        waitsForPromise(() => StateController.canRunKite());
       });
+    });
 
-      withKiteRunning(() => {
-        it('returns a rejected function', () => {
-          waitsForPromise({shouldReject: true}, () => StateController.canRunKite());
-        });
+    withKiteRunning(() => {
+      it('returns a rejected function', () => {
+        waitsForPromise({shouldReject: true}, () => StateController.canRunKite());
       });
     });
   });
@@ -291,25 +280,23 @@ describe('StateController - OSX Support', () => {
       });
     });
 
-    withKiteInstalled(() => {
-      withKiteRunning(() => {
-        it('returns a rejected function', () => {
-          waitsForPromise({shouldReject: true}, () => StateController.runKite());
-        });
+    withKiteRunning(() => {
+      it('returns a rejected function', () => {
+        waitsForPromise({shouldReject: true}, () => StateController.runKite());
       });
+    });
 
-      withKiteNotRunning(() => {
-        it('returns a resolved promise', () => {
-          waitsForPromise(() => StateController.runKite());
-          runs(() => {
-            expect(proc.spawn).toHaveBeenCalledWith('defaults', [
-              'write', 'com.kite.Kite', 'shouldReopenSidebar', '0',
-            ]);
+    withKiteNotRunning(() => {
+      it('returns a resolved promise', () => {
+        waitsForPromise(() => StateController.runKite());
+        runs(() => {
+          expect(proc.spawn).toHaveBeenCalledWith('defaults', [
+            'write', 'com.kite.Kite', 'shouldReopenSidebar', '0',
+          ]);
 
-            expect(proc.spawn).toHaveBeenCalledWith('open', [
-              '-a', OSXSupport.KITE_APP_PATH.installed,
-            ]);
-          });
+          expect(proc.spawn).toHaveBeenCalledWith('open', [
+            '-a', OSXSupport.KITE_APP_PATH.installed,
+          ]);
         });
       });
     });

--- a/spec/support/osx-spec.js
+++ b/spec/support/osx-spec.js
@@ -1,0 +1,306 @@
+
+'use strict';
+
+const os = require('os');
+const https = require('https');
+const proc = require('child_process');
+const StateController = require('../../lib/state-controller');
+const OSXSupport = require('../../lib/support/osx');
+
+const {
+  fakeProcesses, fakeKiteInstallPaths, fakeResponse,
+  withKiteInstalled, withKiteRunning, withKiteNotRunning,
+  withFakeServer,
+} = require('../spec-helpers.js');
+
+describe('StateController - OSX Support', () => {
+  beforeEach(() => {
+    spyOn(os, 'platform').andReturn('darwin');
+  });
+
+  fakeKiteInstallPaths();
+
+  describe('.isKiteSupported()', () => {
+    it('returns a resolved promise for darwin platform', () => {
+      waitsForPromise(() => StateController.isKiteSupported());
+    });
+  });
+
+  describe('.isKiteInstalled()', () => {
+    withKiteInstalled(() => {
+      it('returns a resolved promise', () => {
+        waitsForPromise(() => StateController.isKiteInstalled());
+      });
+    });
+
+    describe('when there is no file at the given path', () => {
+      it('returns a rejected promise', () => {
+        waitsForPromise({
+          shouldReject: true,
+        }, () => StateController.isKiteInstalled());
+      });
+    });
+  });
+
+  describe('.installKite()', () => {
+    describe('when every command succeeds', () => {
+      beforeEach(() => {
+        fakeProcesses({
+          hdiutil: () => 0,
+          cp: () => 0,
+          rm: () => 0,
+        });
+      });
+
+      it('returns a resolved promise', () => {
+        const options = {
+          onInstallStart: jasmine.createSpy(),
+          onMount: jasmine.createSpy(),
+          onCopy: jasmine.createSpy(),
+          onUnmount: jasmine.createSpy(),
+          onRemove: jasmine.createSpy(),
+        };
+
+        waitsForPromise(() => StateController.installKite(options));
+        runs(() => {
+          expect(proc.spawn).toHaveBeenCalledWith('hdiutil', [
+            'attach', '-nobrowse',
+            OSXSupport.KITE_DMG_PATH,
+          ]);
+          expect(proc.spawn).toHaveBeenCalledWith('cp', [
+            '-r',
+            OSXSupport.KITE_APP_PATH.mounted,
+            OSXSupport.APPS_PATH,
+          ]);
+          expect(proc.spawn).toHaveBeenCalledWith('hdiutil', [
+            'detach',
+            OSXSupport.KITE_VOLUME_PATH,
+          ]);
+          expect(proc.spawn).toHaveBeenCalledWith('rm', [
+            OSXSupport.KITE_DMG_PATH,
+          ]);
+
+          expect(options.onInstallStart).toHaveBeenCalled();
+          expect(options.onMount).toHaveBeenCalled();
+          expect(options.onCopy).toHaveBeenCalled();
+          expect(options.onUnmount).toHaveBeenCalled();
+          expect(options.onRemove).toHaveBeenCalled();
+        });
+      });
+    });
+
+    describe('when mounting the archive fails', () => {
+      beforeEach(() => {
+        fakeProcesses({
+          hdiutil: () => 1,
+          cp: () => 0,
+          rm: () => 0,
+        });
+      });
+
+      it('returns a rejected promise', () => {
+        waitsForPromise({shouldReject: true}, () => StateController.installKite());
+      });
+    });
+
+    describe('when copying the archive content fails', () => {
+      beforeEach(() => {
+        fakeProcesses({
+          hdiutil: () => 0,
+          cp: () => 1,
+          rm: () => 0,
+        });
+      });
+
+      it('returns a rejected promise', () => {
+        waitsForPromise({shouldReject: true}, () => StateController.installKite());
+      });
+    });
+
+    describe('when unmounting the archive fails', () => {
+      beforeEach(() => {
+        fakeProcesses({
+          hdiutil: (ps, [command]) => command === 'attach' ? 0 : 1,
+          cp: () => 0,
+          rm: () => 0,
+        });
+      });
+
+      it('returns a rejected promise', () => {
+        waitsForPromise({shouldReject: true}, () => StateController.installKite());
+      });
+    });
+
+    describe('when removing the downloaded archive fails', () => {
+      beforeEach(() => {
+        fakeProcesses({
+          hdiutil: () => 0,
+          cp: () => 0,
+          rm: () => 1,
+        });
+      });
+
+      it('returns a rejected promise', () => {
+        waitsForPromise({shouldReject: true}, () => StateController.installKite());
+      });
+    });
+  });
+
+  describe('.downloadKite()', () => {
+    withFakeServer([
+      [
+        o => /^https:\/\/alpha\.kite\.com/.test(o),
+        o => fakeResponse(303, '', {headers: {location: 'https://download.kite.com'}}),
+      ], [
+        o => /^https:\/\/download\.kite\.com/.test(o),
+        o => fakeResponse(200, 'foo'),
+      ],
+    ], () => {
+      describe('when the download succeeds', () => {
+        beforeEach(() => {
+          fakeProcesses({
+            hdiutil: () => 0,
+            cp: () => 0,
+            rm: () => 0,
+          });
+        });
+
+        describe('with the install option', () => {
+          it('returns a promise resolved after the install', () => {
+            const options = {
+              install: true,
+              onDownload: jasmine.createSpy(),
+              onInstallStart: jasmine.createSpy(),
+              onMount: jasmine.createSpy(),
+              onCopy: jasmine.createSpy(),
+              onUnmount: jasmine.createSpy(),
+              onRemove: jasmine.createSpy(),
+            };
+            const url = 'http://kite.com/download';
+
+            waitsForPromise(() => StateController.downloadKite(url, options));
+            runs(() => {
+              expect(https.request).toHaveBeenCalledWith('https://download.kite.com');
+              expect(proc.spawn).toHaveBeenCalledWith('hdiutil', [
+                'attach', '-nobrowse',
+                OSXSupport.KITE_DMG_PATH,
+              ]);
+              expect(proc.spawn).toHaveBeenCalledWith('cp', [
+                '-r',
+                OSXSupport.KITE_APP_PATH.mounted,
+                OSXSupport.APPS_PATH,
+              ]);
+              expect(proc.spawn).toHaveBeenCalledWith('hdiutil', [
+                'detach',
+                OSXSupport.KITE_VOLUME_PATH,
+              ]);
+              expect(proc.spawn).toHaveBeenCalledWith('rm', [
+                OSXSupport.KITE_DMG_PATH,
+              ]);
+
+              expect(options.onDownload).toHaveBeenCalled();
+              expect(options.onInstallStart).toHaveBeenCalled();
+              expect(options.onMount).toHaveBeenCalled();
+              expect(options.onCopy).toHaveBeenCalled();
+              expect(options.onUnmount).toHaveBeenCalled();
+              expect(options.onRemove).toHaveBeenCalled();
+            });
+          });
+        });
+      });
+    });
+  });
+
+  describe('.isKiteRunning()', () => {
+    describe('when kite is not installed', () => {
+      it('returns a rejected promise', () => {
+        waitsForPromise({shouldReject: true}, () => StateController.isKiteRunning());
+      });
+    });
+
+    withKiteInstalled(() => {
+      describe('but not running', () => {
+        beforeEach(() => {
+          fakeProcesses({
+            '/bin/ps': (ps) => {
+              ps.stdout('');
+              return 0;
+            },
+          });
+        });
+
+        it('returns a rejected promise', () => {
+          waitsForPromise({shouldReject: true}, () => StateController.isKiteRunning());
+        });
+      });
+
+      withKiteRunning(() => {
+        it('returns a resolved promise', () => {
+          waitsForPromise(() => StateController.isKiteRunning());
+        });
+      });
+    });
+  });
+
+  describe('.canRunKite()', () => {
+    describe('when kite is not installed', () => {
+      it('returns a rejected function', () => {
+        waitsForPromise({shouldReject: true}, () => StateController.canRunKite());
+      });
+    });
+
+    withKiteInstalled(() => {
+      describe('but not running', () => {
+        beforeEach(() => {
+          fakeProcesses({
+            '/bin/ps': (ps) => {
+              ps.stdout('');
+              return 0;
+            },
+          });
+        });
+
+        it('returns a resolved promise', () => {
+          waitsForPromise(() => StateController.canRunKite());
+        });
+      });
+
+      withKiteRunning(() => {
+        it('returns a rejected function', () => {
+          waitsForPromise({shouldReject: true}, () => StateController.canRunKite());
+        });
+      });
+    });
+  });
+
+  describe('.runKite()', () => {
+    describe('when kite is not installed', () => {
+      it('returns a rejected function', () => {
+        waitsForPromise({shouldReject: true}, () => StateController.runKite());
+      });
+    });
+
+    withKiteInstalled(() => {
+      withKiteRunning(() => {
+        it('returns a rejected function', () => {
+          waitsForPromise({shouldReject: true}, () => StateController.runKite());
+        });
+      });
+
+      withKiteNotRunning(() => {
+        it('returns a resolved promise', () => {
+          waitsForPromise(() => StateController.runKite());
+          runs(() => {
+            expect(proc.spawn).toHaveBeenCalledWith('defaults', [
+              'write', 'com.kite.Kite', 'shouldReopenSidebar', '0',
+            ]);
+
+            expect(proc.spawn).toHaveBeenCalledWith('open', [
+              '-a', OSXSupport.KITE_APP_PATH.installed,
+            ]);
+          });
+        });
+      });
+    });
+  });
+});

--- a/spec/support/windows-spec.js
+++ b/spec/support/windows-spec.js
@@ -1,0 +1,39 @@
+
+'use strict';
+
+const os = require('os');
+// const https = require('https');
+// const proc = require('child_process');
+const StateController = require('../../lib/state-controller');
+// const WindowsSupport = require('../../lib/support/windows');
+
+const {
+  fakeKiteInstallPaths, /*fakeProcesses, fakeResponse,
+  withKiteInstalled, withKiteRunning, withKiteNotRunning,
+  withFakeServer,*/
+} = require('../spec-helpers.js');
+
+describe('StateController - Windows Support', () => {
+  beforeEach(() => {
+    spyOn(os, 'platform').andReturn('win32');
+    spyOn(os, 'release').andReturn('6.1.3'); // NT6.1 = Windows 7
+  });
+
+  fakeKiteInstallPaths();
+
+  describe('.isKiteSupported()', () => {
+    it('returns a resolved promise', () => {
+      waitsForPromise(() => StateController.isKiteSupported());
+    });
+
+    describe('when the os release is below 6.1', () => {
+      beforeEach(() => {
+        os.release.andReturn('6.0.4'); // NT6.0 = Windows Vista
+      });
+
+      it('returns a rejected promise', () => {
+        waitsForPromise({shouldReject: true}, () => StateController.isKiteSupported());
+      });
+    });
+  });
+});

--- a/spec/support/windows-spec.js
+++ b/spec/support/windows-spec.js
@@ -17,6 +17,7 @@ describe('StateController - Windows Support', () => {
   beforeEach(() => {
     spyOn(os, 'platform').andReturn('win32');
     spyOn(os, 'release').andReturn('6.1.3'); // NT6.1 = Windows 7
+    spyOn(os, 'arch').andReturn('x64'); // NT6.1 = Windows 7
   });
 
   fakeKiteInstallPaths();
@@ -29,6 +30,16 @@ describe('StateController - Windows Support', () => {
     describe('when the os release is below 6.1', () => {
       beforeEach(() => {
         os.release.andReturn('6.0.4'); // NT6.0 = Windows Vista
+      });
+
+      it('returns a rejected promise', () => {
+        waitsForPromise({shouldReject: true}, () => StateController.isKiteSupported());
+      });
+    });
+
+    describe('when the arch is not 64bit', () => {
+      beforeEach(() => {
+        os.arch.andReturn('x86');
       });
 
       it('returns a rejected promise', () => {


### PR DESCRIPTION
The purpose of this PR is to extract every OS-specific code into a support object that is picked using the `os.platform()` function and fallback to a *no support* object for unsupported platform.

That *no support* object implements the same interface as other support objects but returns rejected promises, `false` or `null` when its methods are called.

- [x] Extract OSX specific code in a support object
- [x] Extract OSX specific tests in their own file to keep the main StateController tests os-agnostic.
- [x] Make the tests helpers os-agnostic