### PR TITLE
Escape spaces in windows paths

### DIFF
--- a/lib/support/windows.js
+++ b/lib/support/windows.js
@@ -7,8 +7,9 @@ const KiteError = require('../kite-error');
 
 const {STATES} = require('../constants');
 
-const KEY_BAT = path.join(__dirname, 'read-key.bat');
-const ARCH_BAT = path.join(__dirname, 'read-arch.bat');
+const ESCAPED_DIRNAME = __dirname.replace(/ /g, '\\ ')
+const KEY_BAT = path.join(ESCAPED_DIRNAME, 'read-key.bat');
+const ARCH_BAT = path.join(ESCAPED_DIRNAME, 'read-arch.bat');
 const FALLBACK_INSTALL_PATH = path.join(process.env.ProgramW6432, 'Kite');
 
 function findInstallPath() {


### PR DESCRIPTION
Possible fix for autocomplete-python/autocomplete-python#282.

http://stackoverflow.com/questions/16395612/unable-to-execute-child-process-exec-when-path-has-spaces

Not sure if it's going to break, make sure to test properly. 