### PR TITLE
Fixes existing method that locks up some machines for a sec

### DIFF
--- a/lib/support/read-arch.bat
+++ b/lib/support/read-arch.bat
@@ -1,7 +1,12 @@
 @echo OFF
 setlocal EnableDelayedExpansion
 
-reg Query "HKLM\Hardware\Description\System\CentralProcessor\0" | find /i "x86" > NUL && set OS=32BIT || set OS=64BIT
+REM From : https://blogs.msdn.microsoft.com/david.wang/2006/03/27/howto-detect-process-bitness/
+
+set OS=64BIT
+IF %PROCESSOR_ARCHITECTURE% == x86 (
+  IF NOT DEFINED PROCESSOR_ARCHITEW6432 set OS=32BIT
+)
 
 if %OS%==32BIT echo 32bit
 if %OS%==64BIT echo 64bit


### PR DESCRIPTION
On some Windows machines the reg/find combo seems to lock things up for a few seconds
*I guess this might be Windows Defender or some other anti-virus*

This method works for me and does not introduce that delay ...
I suspect that implementing that logic as pure JS might be even nicer 😃 

I took overall guidance from here : https://ss64.com/nt/syntax-64bit.html