### PR TITLE
Actually fix bat scripts with spaces in path

### DIFF
--- a/lib/support/windows.js
+++ b/lib/support/windows.js
@@ -7,9 +7,8 @@ const KiteError = require('../kite-error');
 
 const {STATES} = require('../constants');
 
-const ESCAPED_DIRNAME = __dirname.replace(/ /g, '\\ ');
-const KEY_BAT = path.join(ESCAPED_DIRNAME, 'read-key.bat');
-const ARCH_BAT = path.join(ESCAPED_DIRNAME, 'read-arch.bat');
+const KEY_BAT = `"${path.join(__dirname, 'read-key.bat')}"`;
+const ARCH_BAT = `"${path.join(__dirname, 'read-arch.bat')}"`;
 const FALLBACK_INSTALL_PATH = path.join(process.env.ProgramW6432, 'Kite');
 
 function findInstallPath() {


### PR DESCRIPTION
#40 didn't fix the problem, but this one should -- tested on Windows 10.
autocomplete-python/autocomplete-python#282
autocomplete-python/autocomplete-python#1