### PR TITLE
VSCode support

### DIFF
--- a/ext/telemetry/localconfig.js
+++ b/ext/telemetry/localconfig.js
@@ -1,22 +1,23 @@
 'use strict';
 
 const fs = require('fs');
+const os = require('os');
 const path = require('path');
 
-const configPath = path.join(path.dirname(atom.config.getUserConfigPath()), 'kite-config.json');
 const Logger = require('../../lib/logger');
+const configPath = typeof atom !== 'undefined'
+  ? path.join(path.dirname(atom.config.getUserConfigPath()), 'kite-config.json')
+  : path.join(os.homedir(), '.kite', 'kite-config.json');
 
 var config = null;
 
-(function() {
-  try {
-    Logger.verbose(`initializing localconfig from ${ configPath }...`);
-    var str = fs.readFileSync(configPath, {encoding: 'utf8'});
-    config = JSON.parse(str);
-  } catch (err) {
-    config = {};
-  }
-})();
+try {
+  Logger.verbose(`initializing localconfig from ${ configPath }...`);
+  var str = fs.readFileSync(configPath, {encoding: 'utf8'});
+  config = JSON.parse(str);
+} catch (err) {
+  config = {};
+}
 
 function persist() {
   var str = JSON.stringify(config, null, 2); // serialize with whitespace for human readability

--- a/ext/telemetry/metrics.js
+++ b/ext/telemetry/metrics.js
@@ -17,7 +17,9 @@ const client = mixpanel.init(MIXPANEL_TOKEN, {
   protocol: 'https',
 });
 
-const EDITOR_UUID = localStorage.getItem('metrics.userId');
+const EDITOR_UUID = typeof localStorage !== 'undefined'
+  ? localStorage.getItem('metrics.userId')
+  : undefined;
 
 // Generate a unique ID for this user and save it for future use.
 function distinctID() {

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -17,11 +17,11 @@ const Logger = {
   LEVELS,
 
   METHODS: {
-    [LEVELS.SILLY]: 'debug',
-    [LEVELS.VERBOSE]: 'debug',
+    [LEVELS.SILLY]: 'debug' in console ? 'debug' : 'log',
+    [LEVELS.VERBOSE]: 'debug' in console ? 'debug' : 'log',
     [LEVELS.DEBUG]: 'log',
-    [LEVELS.INFO]: 'info',
-    [LEVELS.WARN]: 'warn',
+    [LEVELS.INFO]: 'info' in console ? 'info' : 'log',
+    [LEVELS.WARN]: 'warn' in console ? 'warn' : 'error',
     [LEVELS.ERROR]: 'error',
   },
 


### PR DESCRIPTION
- [x] Do not depend on Atom's config path
- [x] Do not rely on local storage
- [ ] Make decision-maker context aware
- [ ] Do not expose atom helpers unless in Atom
- [ ] Allow to have a different set of install UIs depending on the editor
- [ ] Make package installation at the end of install optional