### PR TITLE
Remove admin check on windows

### DIFF
--- a/lib/support/windows.js
+++ b/lib/support/windows.js
@@ -58,12 +58,13 @@ const WindowsSupport = {
   },
 
   isAdmin() {
-    try {
-      child_process.execSync('net session');
-      return true;
-    } catch (e) {
-      return false;
-    }
+    return true;
+    // try {
+    //   child_process.execSync('net session');
+    //   return true;
+    // } catch (e) {
+    //   return false;
+    // }
   },
 
   arch() {


### PR DESCRIPTION
This is done by considering every user an admin (so we don't need to
introduce os-specific stuff higher in the abstractions)