### PR TITLE
Use a getter to compute windows install path and add a new fallback path

### DIFF
--- a/lib/support/windows.js
+++ b/lib/support/windows.js
@@ -9,25 +9,42 @@ const {STATES} = require('../constants');
 
 const KEY_BAT = `"${path.join(__dirname, 'read-key.bat')}"`;
 const ARCH_BAT = `"${path.join(__dirname, 'read-arch.bat')}"`;
-const FALLBACK_INSTALL_PATH = path.join(process.env.ProgramW6432, 'Kite');
 
-function findInstallPath() {
-  try {
-    const registryPath = String(child_process.execSync(KEY_BAT)).trim();
-
-    return registryPath !== 'not found'
-      ? registryPath
-      : FALLBACK_INSTALL_PATH;
-  } catch (err) {
-    return FALLBACK_INSTALL_PATH;
-  }
-}
+let COMPUTED_INSTALL_PATH;
 
 const WindowsSupport = {
   RELEASE_URL: 'https://alpha.kite.com/release/dls/windows/current',
   KITE_INSTALLER_PATH: path.join(os.tmpdir(), 'KiteSetup.exe'),
-  KITE_EXE_PATH: path.join(findInstallPath(), 'kited.exe'),
   SESSION_FILE_PATH: path.join(process.env.LOCALAPPDATA, 'Kite', 'session.json'),
+  // We're only setting the install path in tests
+  set KITE_EXE_PATH(path) {
+    COMPUTED_INSTALL_PATH = path;
+  },
+  get KITE_EXE_PATH() {
+    if (!COMPUTED_INSTALL_PATH) {
+      let installDir, fallbackInstallDir;
+
+      if (process.env.ProgramW6432) {
+        fallbackInstallDir = path.join(process.env.ProgramW6432, 'Kite');
+      } else {
+        // TODO: report that even the fallback needed a fallback
+        fallbackInstallDir = 'C:\\Program Files\\Kite';
+      }
+
+      try {
+        const registryDir = String(child_process.execSync(KEY_BAT)).trim();
+
+        installDir = registryDir !== 'not found'
+          ? registryDir
+          : fallbackInstallDir;
+      } catch (err) {
+        installDir = fallbackInstallDir;
+      }
+      COMPUTED_INSTALL_PATH = path.join(installDir, 'kited.exe');
+    }
+
+    return COMPUTED_INSTALL_PATH;
+  },
 
   get releaseURL() {
     return this.RELEASE_URL;


### PR DESCRIPTION
In case ProgramW6432 is undefined we fall back to a hardcoded path and
let room to report that back to the editors