### PR TITLE
Support async Kite install in ACP/Atom

### DIFF
--- a/lib/elements/atom/install-error-view.js
+++ b/lib/elements/atom/install-error-view.js
@@ -1,0 +1,30 @@
+'use strict';
+
+const InstallError = require('./install-error-element');
+const {logo} = require('./assets');
+
+class InstallErrorView extends HTMLElement {
+  constructor(install) {
+    super();
+    this.name = 'kite_install_error_view';
+
+    this.innerHTML = `<div class="install-wrapper">
+      <div class="logo">${logo}</div>
+      <div class="content">
+      </div>  
+    </div>`;
+
+    let errorElement = new InstallError('kite_installer_install_error');
+    this.querySelector('.content').appendChild(errorElement);
+    errorElement.init(install);
+  }
+
+  // noinspection JSMethodCanBeStatic
+  getTitle() {
+    return 'Kite Install Error';
+  }
+}
+
+customElements.define('kite-atom-install-error-view', InstallErrorView);
+
+module.exports = InstallErrorView;

--- a/lib/elements/atom/install-statusbar-element.js
+++ b/lib/elements/atom/install-statusbar-element.js
@@ -1,0 +1,79 @@
+'use strict';
+
+const CompositeDisposable = require('../../install/composite-disposable');
+
+class InstallStatusBarElement extends HTMLElement {
+  constructor(name) {
+    super();
+    this.name = name;
+    this.className = 'kite-install-status';
+    this.classList.add('inline-block');
+    this.subscriptions = new CompositeDisposable();
+    this.currentStatusText = '';
+  }
+
+  destroyTile() {
+    if (this.subscriptions) {
+      this.subscriptions.dispose();
+      this.subscriptions = null;
+    }
+    if (this.statusBarTile) {
+      this.statusBarTile.destroy();
+      this.statusBarTile = null;
+    }
+  }
+
+  init(install, statusBar) {
+    this.subscriptions.add(atom.tooltips.add(this, {
+      title: 'Kite will start automatically after being installed'
+    }));
+
+    this.statusBarTile = statusBar.addRightTile({item: this});
+    this.subscriptions.add(install.on('encountered-fatal-error', (err) => {
+      console.log('fatal status bar error: ' + err);
+      this.destroyTile();
+    }));
+
+    this.subscriptions.add(install.onDidFailStep(({error}) => {
+      console.log('fatal status bar error:' + (error && error.message));
+      this.destroyTile();
+    }));
+
+    this.subscriptions.add(install.observeState((state) => {
+      let newStatusText;
+      if (state.download) {
+        newStatusText = 'Downloading Kite';
+      }
+
+      if ((state.download && state.download.done) || state.install) {
+        newStatusText = 'Installing Kite';
+      }
+
+      if (state.running) {
+        newStatusText = 'Starting Kite';
+      }
+
+      if (state.plugin) {
+        if (state.plugin.done) {
+          this.destroyTile();
+          newStatusText = '';
+        } else {
+          newStatusText = 'Installing Kite plugin';
+        }
+      }
+
+      if (newStatusText && newStatusText !== this.currentStatusText) {
+        this.currentStatusText = newStatusText;
+        this.innerHTML = `<span class="loading loading-spinner-tiny inline-block icon"></span><span class="text"> ${newStatusText}</span>`;
+      }
+    }));
+  }
+
+  release() {
+    // this.destroyTile()
+  }
+}
+
+customElements.define('kite-atom-install-statusbar', InstallStatusBarElement);
+
+module.exports = InstallStatusBarElement;

--- a/lib/elements/atom/install-wait-element.js
+++ b/lib/elements/atom/install-wait-element.js
@@ -9,10 +9,6 @@ class InstallWaitElement extends HTMLElement {
     this.name = name;
     this.innerHTML = `
     <div class="welcome-to-kite">
-      <div class="warning">
-        <span class="icon">⚠️</span>
-        <span class="message">Kite is still installing on your machine. Please do not close this tab until installation has finished.</span>
-      </div>
       <div class="description">
         <div class="content">
           <p>Kite comes with a native desktop app called the Copilot which provides you with real time documentation as you code.</p>

--- a/lib/index.js
+++ b/lib/index.js
@@ -20,14 +20,18 @@ module.exports = {
   BrowserClient: BrowserClient,
   utils: utils,
   install: install,
+  statusBar: null,
 };
 
 if (typeof atom !== 'undefined') {
   const startFlow = (flow) => {
+    const statusBar = this.statusBar;
+
     const Install = install.Install;
     const installer = new Install(flow(), {
       path: atom.project.getPaths()[0] || os.homedir(),
     }, {
+      statusBar: statusBar,
       failureStep: 'termination',
       title: 'Kite Install',
     });
@@ -47,6 +51,10 @@ if (typeof atom !== 'undefined') {
   };
 
   module.exports.AtomHelper = require('./atom-helper');
+
+  module.exports.consumeStatusBar = (statusBar) => {
+    this.statusBar = statusBar;
+  };
 
   module.exports.startInstallFlow = () => {
     startFlow(install.atom().defaultFlow);

--- a/lib/install.js
+++ b/lib/install.js
@@ -25,7 +25,6 @@ module.exports = class Install {
       error && rollbar.error(error, error.data);
 
       if (this.state.destroyed) {
-        //this.updateState({error});
         this.emit("headless-error", {error, state: this.state})
       }
     });

--- a/lib/install.js
+++ b/lib/install.js
@@ -23,6 +23,11 @@ module.exports = class Install {
 
     this.flow.onDidFailStep(({error}) => {
       error && rollbar.error(error, error.data);
+
+      if (this.state.destroyed) {
+        //this.updateState({error});
+        this.emit("headless-error", {error, state: this.state})
+      }
     });
   }
 
@@ -69,6 +74,9 @@ module.exports = class Install {
   }
 
   destroy() {
+    this.updateState({
+      destroyed: true
+    })
     this.emit('did-destroy');
   }
 

--- a/lib/install/base-step.js
+++ b/lib/install/base-step.js
@@ -16,4 +16,6 @@ module.exports = class BaseStep {
   release() { this.subscriptions.dispose(); }
 
   getView() { return this.view; }
+
+  getStatusBar() { return this.options.statusBar; }
 };

--- a/lib/install/flow.js
+++ b/lib/install/flow.js
@@ -2,7 +2,7 @@
 
 const Emitter = require('./emitter');
 const BaseStep = require('./base-step');
-const { CompositeDisposable } = require('atom');
+const CompositeDisposable = require('./composite-disposable');
 
 module.exports = class Flow extends BaseStep {
   constructor(steps = [], options) {

--- a/lib/install/flow.js
+++ b/lib/install/flow.js
@@ -2,7 +2,6 @@
 
 const Emitter = require('./emitter');
 const BaseStep = require('./base-step');
-const InstallStatusElement = require('../elements/atom/install-statusbar-element')
 
 module.exports = class Flow extends BaseStep {
   constructor(steps = [], options) {
@@ -26,6 +25,8 @@ module.exports = class Flow extends BaseStep {
       return;
     }
 
+    // init late because we need HTMLElement
+    const InstallStatusElement = require('../elements/atom/install-statusbar-element');
     let installStatus = new InstallStatusElement("kite-install-status");
     installStatus.init(install, statusBar)
   }

--- a/lib/install/flow.js
+++ b/lib/install/flow.js
@@ -2,7 +2,7 @@
 
 const Emitter = require('./emitter');
 const BaseStep = require('./base-step');
-const CompositeDisposable = require('./composite-disposable');
+const InstallStatusElement = require('../elements/atom/install-statusbar-element')
 
 module.exports = class Flow extends BaseStep {
   constructor(steps = [], options) {
@@ -20,81 +20,21 @@ module.exports = class Flow extends BaseStep {
     return this.emitter.on('did-fail-step', listener);
   }
 
-  updateStatusBar() {
+  installStatusBarElement(install) {
     let statusBar = this.getStatusBar();
     if (!statusBar) {
       return;
     }
 
-    if (!this.statusElement) {
-      this.statusElement = document.createElement('div');
-      this.statusElement.className = 'kite-install-status';
-      this.statusElement.classList.add('inline-block');
-
-      let statusElement = this.statusElement;
-
-      let subscriptions = new CompositeDisposable();
-      subscriptions.add(atom.tooltips.add(statusElement, {
-        title: 'Kite will start automatically after being installed'
-      }));
-
-      let statusBarTile = statusBar.addRightTile({item: statusElement});
-
-      function destroyTile() {
-        if (subscriptions) {
-          subscriptions.dispose();
-          subscriptions = null;
-        }
-        if (statusBarTile) {
-          statusBarTile.destroy();
-          statusBarTile = null;
-        }
-      }
-
-      subscriptions.add(this.install.on('encountered-fatal-error', () => {
-        destroyTile();
-      }));
-
-      let currentStatusText;
-      subscriptions.add(this.install.observeState((state) => {
-        let newStatusText;
-        if (state.download) {
-          newStatusText = 'Downloading Kite';
-          if (state.download.done) {
-            newStatusText = 'Installing Kite';
-          }
-        }
-
-        if (state.install) {
-          newStatusText = 'Installing Kite';
-        }
-
-        if (state.running) {
-          newStatusText = 'Starting Kite';
-        }
-
-        if (state.plugin) {
-          if (state.plugin.done) {
-            destroyTile();
-            newStatusText = "";
-          } else {
-            newStatusText = 'Installing Kite plugin';
-          }
-        }
-
-        if (newStatusText && newStatusText !== currentStatusText) {
-          currentStatusText = newStatusText;
-          statusElement.innerHTML = `<span class="loading loading-spinner-tiny inline-block icon"></span><span class="text"> ${newStatusText}</span>`;
-        }
-      }));
-    }
+    let installStatus = new InstallStatusElement("kite-install-status");
+    installStatus.init(install, statusBar)
   }
 
   start(state, install) {
     this.install = install;
     const firstStep = this.steps[this.currentStepIndex];
     if (firstStep) {
-      this.updateStatusBar();
+      this.installStatusBarElement(install);
       return this.executeStep(firstStep);
     }
     return Promise.resolve();

--- a/lib/install/flow.js
+++ b/lib/install/flow.js
@@ -20,7 +20,7 @@ module.exports = class Flow extends BaseStep {
     return this.emitter.on('did-fail-step', listener);
   }
 
-  updateStatusBar(statusText, state) {
+  updateStatusBar() {
     let statusBar = this.getStatusBar();
     if (!statusBar) {
       return;
@@ -29,11 +29,16 @@ module.exports = class Flow extends BaseStep {
     if (!this.statusElement) {
       this.statusElement = document.createElement('div');
       this.statusElement.className = 'kite-install-status';
-      this.statusElement.innerHTML = `<span class="text" title="Kite will start automatically after being installed"></span>`;
       this.statusElement.classList.add('inline-block');
 
+      let statusElement = this.statusElement;
+
       let subscriptions = new CompositeDisposable();
-      let statusBarTile = statusBar.addLeftTile({item: this.statusElement});
+      subscriptions.add(atom.tooltips.add(statusElement, {
+        title: 'Kite will start automatically after being installed'
+      }));
+
+      let statusBarTile = statusBar.addRightTile({item: statusElement});
 
       function destroyTile() {
         if (subscriptions) {
@@ -50,6 +55,7 @@ module.exports = class Flow extends BaseStep {
         destroyTile();
       }));
 
+      let currentStatusText;
       subscriptions.add(this.install.observeState((state) => {
         let newStatusText;
         if (state.download) {
@@ -76,8 +82,9 @@ module.exports = class Flow extends BaseStep {
           }
         }
 
-        if (newStatusText) {
-          this.statusElement.innerHTML = `<span class="text" title="Kite will start automatically after being installed">${newStatusText}</span>`;
+        if (newStatusText && newStatusText !== currentStatusText) {
+          currentStatusText = newStatusText;
+          statusElement.innerHTML = `<span class="loading loading-spinner-tiny inline-block icon"></span><span class="text"> ${newStatusText}</span>`;
         }
       }));
     }

--- a/lib/install/flow.js
+++ b/lib/install/flow.js
@@ -2,6 +2,7 @@
 
 const Emitter = require('./emitter');
 const BaseStep = require('./base-step');
+const { CompositeDisposable } = require('atom');
 
 module.exports = class Flow extends BaseStep {
   constructor(steps = [], options) {
@@ -19,12 +20,77 @@ module.exports = class Flow extends BaseStep {
     return this.emitter.on('did-fail-step', listener);
   }
 
+  updateStatusBar(statusText, state) {
+    let statusBar = this.getStatusBar();
+    if (!statusBar) {
+      return;
+    }
+
+    if (!this.statusElement) {
+      this.statusElement = document.createElement('div');
+      this.statusElement.className = 'kite-install-status';
+      this.statusElement.innerHTML = `<span class="text" title="Kite will start automatically after being installed"></span>`;
+      this.statusElement.classList.add('inline-block');
+
+      let subscriptions = new CompositeDisposable();
+      let statusBarTile = statusBar.addLeftTile({item: this.statusElement});
+
+      function destroyTile() {
+        if (subscriptions) {
+          subscriptions.dispose();
+          subscriptions = null;
+        }
+        if (statusBarTile) {
+          statusBarTile.destroy();
+          statusBarTile = null;
+        }
+      }
+
+      subscriptions.add(this.install.on('encountered-fatal-error', () => {
+        destroyTile();
+      }));
+
+      subscriptions.add(this.install.observeState((state) => {
+        let newStatusText;
+        if (state.download) {
+          newStatusText = 'Downloading Kite';
+          if (state.download.done) {
+            newStatusText = 'Installing Kite';
+          }
+        }
+
+        if (state.install) {
+          newStatusText = 'Installing Kite';
+        }
+
+        if (state.running) {
+          newStatusText = 'Starting Kite';
+        }
+
+        if (state.plugin) {
+          if (state.plugin.done) {
+            destroyTile();
+            newStatusText = "";
+          } else {
+            newStatusText = 'Installing Kite plugin';
+          }
+        }
+
+        if (newStatusText) {
+          this.statusElement.innerHTML = `<span class="text" title="Kite will start automatically after being installed">${newStatusText}</span>`;
+        }
+      }));
+    }
+  }
+
   start(state, install) {
     this.install = install;
     const firstStep = this.steps[this.currentStepIndex];
-    return firstStep
-      ? this.executeStep(firstStep)
-      : Promise.resolve();
+    if (firstStep) {
+      this.updateStatusBar();
+      return this.executeStep(firstStep);
+    }
+    return Promise.resolve();
   }
 
   executeStep(step) {

--- a/lib/install/index.js
+++ b/lib/install/index.js
@@ -14,6 +14,8 @@ const ParallelSteps = require('./parallel-steps');
 const PassStep = require('./pass-step');
 const VoidStep = require('./void-step');
 
+const InstallErrorView = require('../elements/atom/install-error-view');
+
 const KiteAPI = require('kite-api');
 
 module.exports = {
@@ -30,6 +32,7 @@ module.exports = {
   Login,
   ParallelSteps,
   VoidStep,
+  InstallErrorView,
 
   atom: () => {
     const InstallElement = require('../elements/atom/install-element');

--- a/package-lock.json
+++ b/package-lock.json
@@ -1922,9 +1922,9 @@
       }
     },
     "kite-connector": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/kite-connector/-/kite-connector-3.6.0.tgz",
-      "integrity": "sha512-hJZwTeXjmNUHVP83lEWINZ+ptLACIvjNJdg0F2D7bhq41te0SWsedG6SMofw3aWjBBdxu8n7dxIOkwa4kZiGQg==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/kite-connector/-/kite-connector-3.7.0.tgz",
+      "integrity": "sha512-jjBIbjAUqWHy6+4YUDFdQM5GLWw9QDHdHAQEQGNVX3Oa1fw1V+N2DT8eu594bNyg1w687/VDEhaD9RoHXLnY1Q==",
       "requires": {
         "form-data": "^2.3.2"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1922,9 +1922,9 @@
       }
     },
     "kite-connector": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/kite-connector/-/kite-connector-3.7.0.tgz",
-      "integrity": "sha512-jjBIbjAUqWHy6+4YUDFdQM5GLWw9QDHdHAQEQGNVX3Oa1fw1V+N2DT8eu594bNyg1w687/VDEhaD9RoHXLnY1Q==",
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/kite-connector/-/kite-connector-3.8.0.tgz",
+      "integrity": "sha512-nJCLJUKS2RxyagMWyjhqwP5i+cDc05hxVUQZfXfsEhw+1WfXe9Vzg6WuUbAI5JTiJOjiXOaVo+nrYl/VJqC/UQ==",
       "requires": {
         "form-data": "^2.3.2"
       }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,13 @@
     "test-nocov": "mocha --timeout 20000 --recursive test/*.test.js test/**/*.test.js",
     "test": "nyc mocha --timeout 20000 --recursive test/*.test.js test/**/*.test.js"
   },
+  "consumedServices": {
+    "status-bar": {
+      "versions": {
+        "^1.0.0": "consumeStatusBar"
+      }
+    }
+  },
   "dependencies": {
     "mixpanel": "^0.5.0",
     "kite-api": "3.6.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "mixpanel": "^0.5.0",
     "kite-api": "3.6.0",
-    "kite-connector": "3.7.0",
+    "kite-connector": "3.8.0",
     "rollbar": "^2.4.4"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "mixpanel": "^0.5.0",
     "kite-api": "3.6.0",
-    "kite-connector": "3.6.0",
+    "kite-connector": "3.7.0",
     "rollbar": "^2.4.4"
   },
   "devDependencies": {

--- a/styles/install.less
+++ b/styles/install.less
@@ -334,3 +334,11 @@ kite-atom-install, kite-atom-install-error-view {
     }
   }
 }
+
+status-bar .status-bar-right {
+  kite-atom-install-statusbar {
+    .loading-spinner-tiny {
+      margin-right: 0.5rem !important;
+    }
+  }
+}

--- a/styles/install.less
+++ b/styles/install.less
@@ -1,7 +1,7 @@
 @import "syntax-variables";
 @import "ui-variables";
 
-kite-atom-install {
+kite-atom-install, kite-atom-install-error-view {
   display: block;
   overflow: auto;
   margin: 0 auto;


### PR DESCRIPTION
Spec: https://kite.quip.com/3zTuAFFCSq4v/autocomplete-python-Asynchronous-Install

- Show status of the ongoing installation in Atom's statusbar. ACP has to pass a value for statusBar to make this work.
- Remove warning about the closing of the current tab
- Reopen tab when an error occurred after closing the initial installation flow

cc @metalogical 

Demo installing Kite on Linux and forcibly terminating early:
![kite-async-install](https://user-images.githubusercontent.com/11473063/62789992-6b6d5c00-baca-11e9-89de-9a7d71611f06.gif)
