### PR TITLE
Install the Atom Kite plugin before installing Kite and launching Copilot

### DIFF
--- a/lib/install/index.js
+++ b/lib/install/index.js
@@ -134,8 +134,8 @@ module.exports = {
           }),
           new ParallelSteps([
             new Flow([
-              new Download({name: 'download'}),
               new InstallPlugin({name: 'install-plugin'}),
+              new Download({name: 'download'}),
             ], {name: 'download-flow'}),
             new PassStep({
               name: 'wait-step',


### PR DESCRIPTION
Previous it was 
1. install kite
2. install Atom plugin

Now it's in reverse order to let Copilot detect an installed Kite plugin