### PR TITLE
acp: activate plugin after starting kite in the background

### DIFF
--- a/lib/install/download.js
+++ b/lib/install/download.js
@@ -12,6 +12,8 @@ module.exports = class Download extends BaseStep {
 
     this.installInterval = 1500;
     this.runInterval = 2500;
+    // fallback to true, i.e. the logic before this options was added
+    this.startCopilot = options.startCopilot !== false;
   }
 
   start(state, install) {
@@ -36,7 +38,7 @@ module.exports = class Download extends BaseStep {
         install: {done: true},
         running: {done: false},
       });
-      return KiteAPI.runKiteAndWait(30, this.runInterval)
+      return KiteAPI.runKiteAndWait(30, this.runInterval, this.startCopilot)
       .then(() => {
         Metrics.Tracker.trackEvent('kite_installer_kite_app_started');
         install.updateState({running: {done: true}});

--- a/lib/install/download.js
+++ b/lib/install/download.js
@@ -13,7 +13,7 @@ module.exports = class Download extends BaseStep {
     this.installInterval = 1500;
     this.runInterval = 2500;
     // fallback to true, i.e. the logic before this options was added
-    this.startCopilot = options.startCopilot !== false;
+    this.startCopilot = !options || options.startCopilot !== false;
   }
 
   start(state, install) {

--- a/lib/install/index.js
+++ b/lib/install/index.js
@@ -3,6 +3,7 @@ const BranchStep = require('./branch-step');
 const CheckEmail = require('./check-email');
 const CreateAccount = require('./create-account');
 const Download = require('./download');
+const LaunchCopilot = require('./launchCopilot');
 const Flow = require('./flow');
 const GetEmail = require('./get-email');
 const InputEmail = require('./input-email');
@@ -21,6 +22,7 @@ module.exports = {
   CheckEmail,
   CreateAccount,
   Download,
+  LaunchCopilot,
   Flow,
   GetEmail,
   InputEmail,
@@ -96,7 +98,7 @@ module.exports = {
           }),
           new ParallelSteps([
             new Flow([
-              new Download({name: 'download'}),
+              new Download({name: 'download', startCopilot: true}),
               new Authenticate({name: 'authenticate'}),
               new InstallPlugin({name: 'install-plugin'}),
             ], {name: 'download-flow'}),
@@ -133,8 +135,9 @@ module.exports = {
           }),
           new ParallelSteps([
             new Flow([
+              new Download({name: 'download', startCopilot: false}),
               new InstallPlugin({name: 'install-plugin'}),
-              new Download({name: 'download'}),
+              new LaunchCopilot({name: 'launch-copilot'}),
             ], {name: 'download-flow'}),
             new PassStep({
               name: 'wait-step',

--- a/lib/install/launchCopilot.js
+++ b/lib/install/launchCopilot.js
@@ -1,0 +1,24 @@
+'use strict';
+
+const KiteAPI = require('kite-api');
+const {retryPromise} = require('kite-connector/lib/utils');
+
+const BaseStep = require('./base-step');
+
+module.exports = class LaunchCopilot extends BaseStep {
+  constructor(options) {
+    super(options);
+
+    this.runInterval = 2500;
+  }
+
+  start(state, install) {
+    return retryPromise(() => KiteAPI.isKiteInstalled(), 10, this.installInterval)
+    .then(() => {
+      return KiteAPI.runKiteAndWait(30, this.runInterval, true)
+      .then(() => {
+        install.updateState({running: {done: true}});
+      });
+    });
+  }
+};


### PR DESCRIPTION
change logic from "install kite plugin -> install kite & open copilot" to "install kite & run without copilot -> install kite plugin -> open copilot" to let the Kite plugin show the onboarding file (which is retrieved from kited)

How to test:
- it's best to release a version of this for easier testing. I'm not sure about side-effects with packages using it, i.e. the VSCode plugin (and perhaps others)
- remove all Kite settings from Atom>Config
- uninstall Kite plugin
- uninstall Kite
- remove $HOME/.kite (to remove has_done_onboarding flag and possibly more)
- update acp's package json 
- `apm link` in our branch of `autocomplete-python`
- start atom -> the onboarding should appear

This is how it looks like on Linux with default settings:
![Screenshot_20190821_141109](https://user-images.githubusercontent.com/11473063/63432532-a1db9d00-c421-11e9-853f-60150cd4aea4.png)
