### PR TITLE
Support for Bundling with Webpack and Centralized Default Flow for Installation

### DIFF
--- a/lib/elements/atom/assets.js
+++ b/lib/elements/atom/assets.js
@@ -1,13 +1,22 @@
 const fs = require('fs');
 const path = require('path');
 
-const WEBPACK_FILELOADER_PATH_KEY = "default";
+let LogoPath = '../../../assets/logo.svg';
+let LogoSmallPath = '../../../assets/logo-small.svg';
+let ScreenshotPath = '../../../assets/plotscreenshot.png';
+let DemoVideoPath = '../../../assets/demo.mp4';
+let InstallLessPath = '../../../styles/install.less';
 
-const LogoPath = require('../../../assets/logo.svg')[WEBPACK_FILELOADER_PATH_KEY];
-const LogoSmallPath = require('../../../assets/logo-small.svg')[WEBPACK_FILELOADER_PATH_KEY];
-const ScreenshotPath = require('../../../assets/plotscreenshot.png')[WEBPACK_FILELOADER_PATH_KEY];
-const DemoVideoPath = require('../../../assets/demo.mp4')[WEBPACK_FILELOADER_PATH_KEY];
-const InstallLessPath = require('../../../styles/install.less')[WEBPACK_FILELOADER_PATH_KEY];
+// Environment variable set by consumer repository using Webpack Plugins via config.
+if (process.env.USING_WEBPACK_FILELOADER_TO_BUNDLE) {
+  const WEBPACK_FILELOADER_PATH_KEY = "default";
+
+  LogoPath = require('../../../assets/logo.svg')[WEBPACK_FILELOADER_PATH_KEY];
+  LogoSmallPath = require('../../../assets/logo-small.svg')[WEBPACK_FILELOADER_PATH_KEY];
+  ScreenshotPath = require('../../../assets/plotscreenshot.png')[WEBPACK_FILELOADER_PATH_KEY];
+  DemoVideoPath = require('../../../assets/demo.mp4')[WEBPACK_FILELOADER_PATH_KEY];
+  InstallLessPath = require('../../../styles/install.less')[WEBPACK_FILELOADER_PATH_KEY];
+}
 
 const logo = String(fs.readFileSync(path.resolve(__dirname, LogoPath)));
 

--- a/lib/elements/atom/assets.js
+++ b/lib/elements/atom/assets.js
@@ -1,12 +1,19 @@
 const fs = require('fs');
 const path = require('path');
 
-const logo = String(fs.readFileSync(path.resolve(__dirname, '..', '..', '..', 'assets', 'logo.svg')));
+const PATH_KEY = "default";
 
-const logoSmall = String(fs.readFileSync(path.resolve(__dirname, '..', '..', '..', 'assets', 'logo-small.svg')));
+const LogoPath = require('../../../assets/logo.svg')[PATH_KEY];
+const LogoSmallPath = require('../../../assets/logo-small.svg')[PATH_KEY];
+const ScreenshotPath = require('../../../assets/plotscreenshot.png')[PATH_KEY];
+const DemoVideoPath = require('../../../assets/demo.mp4')[PATH_KEY];
 
-const screenshot = path.resolve(__dirname, '..', '..', '..', 'assets', 'plotscreenshot.png');
+const logo = String(fs.readFileSync(path.resolve(__dirname, LogoPath)));
 
-const demoVideo = path.resolve(__dirname, '..', '..', '..', 'assets', 'demo.mp4');
+const logoSmall = String(fs.readFileSync(path.resolve(__dirname, LogoSmallPath)));
+
+const screenshot = path.resolve(__dirname, ScreenshotPath);
+
+const demoVideo = path.resolve(__dirname, DemoVideoPath);
 
 module.exports = {logo, logoSmall, screenshot, demoVideo};

--- a/lib/elements/atom/assets.js
+++ b/lib/elements/atom/assets.js
@@ -1,12 +1,13 @@
 const fs = require('fs');
 const path = require('path');
 
-const PATH_KEY = "default";
+const WEBPACK_FILELOADER_PATH_KEY = "default";
 
-const LogoPath = require('../../../assets/logo.svg')[PATH_KEY];
-const LogoSmallPath = require('../../../assets/logo-small.svg')[PATH_KEY];
-const ScreenshotPath = require('../../../assets/plotscreenshot.png')[PATH_KEY];
-const DemoVideoPath = require('../../../assets/demo.mp4')[PATH_KEY];
+const LogoPath = require('../../../assets/logo.svg')[WEBPACK_FILELOADER_PATH_KEY];
+const LogoSmallPath = require('../../../assets/logo-small.svg')[WEBPACK_FILELOADER_PATH_KEY];
+const ScreenshotPath = require('../../../assets/plotscreenshot.png')[WEBPACK_FILELOADER_PATH_KEY];
+const DemoVideoPath = require('../../../assets/demo.mp4')[WEBPACK_FILELOADER_PATH_KEY];
+const InstallLessPath = require('../../../styles/install.less')[WEBPACK_FILELOADER_PATH_KEY];
 
 const logo = String(fs.readFileSync(path.resolve(__dirname, LogoPath)));
 
@@ -16,4 +17,6 @@ const screenshot = path.resolve(__dirname, ScreenshotPath);
 
 const demoVideo = path.resolve(__dirname, DemoVideoPath);
 
-module.exports = {logo, logoSmall, screenshot, demoVideo};
+const installLess = path.resolve(__dirname, InstallLessPath);
+
+module.exports = {logo, logoSmall, screenshot, demoVideo, installLess};

--- a/lib/elements/atom/install-element.js
+++ b/lib/elements/atom/install-element.js
@@ -3,7 +3,7 @@
 const {CompositeDisposable} = require('atom');
 const path = require('path');
 const Install = require('../../install');
-const {logo} =  require('./assets');
+const {logo, installLess} =  require('./assets');
 
 const Metrics = require('../../../ext/telemetry/metrics');
 
@@ -12,7 +12,7 @@ class InstallElement extends HTMLElement {
     const elementClass = document.registerElement('kite-atom-install', {
       prototype: this.prototype,
     });
-    atom.themes.requireStylesheet(path.resolve(__dirname, '..', '..', '..', 'styles', 'install.less'));
+    atom.themes.requireStylesheet(installLess);
     atom.views.addViewProvider(Install, model => {
       const element = new elementClass();
       element.setModel(model);

--- a/lib/install/index.js
+++ b/lib/install/index.js
@@ -45,6 +45,50 @@ module.exports = {
 
     const InstallPlugin = require('./install-plugin');
 
+    const defaultFlow = () => {
+      return [
+        new ParallelSteps([
+          new Flow([
+            new Download({name: 'download'}),
+            new InstallPlugin({name: 'install-plugin'}),
+            new RunKiteWithCopilot({name: 'launch-copilot'}),
+          ], {name: 'download-flow'}),
+          new PassStep({
+            name: 'wait-step',
+            view: new InstallWaitElement('kite_installer_wait_step'),
+          }),
+        ], {
+          name: 'download-and-wait',
+        }),
+        new BranchStep([
+          {
+            match: (data) => !data.error,
+            step: new VoidStep({
+              name: 'end',
+              view: new InstallEndElement('kite_installer_install_end_step'),
+            }),
+          }, 
+          {
+            match: (data) => data.error,
+            step: new VoidStep({
+              name: 'error',
+              view: new InstallErrorElement('kite_installer_install_error_step'),
+            }),
+          },
+        ], {name: 'termination'}),
+      ];
+    }
+
+    const autocompletePythonFlow = () => {
+      return [
+        new KiteVsJedi({
+          name: 'kite-vs-jedi',
+          view: new KiteVsJediElement('kite_installer_choose_kite_step'),
+        }),
+        ...defaultFlow()
+      ];
+    }
+
     return {
       InstallElement,
       InputEmailElement,
@@ -56,115 +100,8 @@ module.exports = {
       InstallErrorView,
       InstallPlugin,
 
-      defaultFlow: () => {
-        return [
-          new BranchStep([
-            {
-              match: (data) => KiteAPI.isAdmin(),
-              step: new GetEmail({name: 'get-email'}),
-            }, {
-              match: (data) => !KiteAPI.isAdmin(),
-              step: new VoidStep({
-                name: 'not-admin',
-                view: new NotAdminElement('kite_installer_not_admin_step'),
-              }),
-            },
-          ], {
-            name: 'admin-check',
-          }),
-          new InputEmail({
-            name: 'input-email',
-            view: new InputEmailElement('kite_installer_input_email_step'),
-          }),
-          new CheckEmail({
-            name: 'check-email',
-            failureStep: 'input-email',
-          }),
-          new BranchStep([
-            {
-              match: (data) => data.account.exists,
-              step: new Login({
-                name: 'login',
-                view: new LoginElement('kite_installer_login_step'),
-                failureStep: 'account-switch',
-                backStep: 'input-email',
-              }),
-            }, {
-              match: (data) => !data.account.exists,
-              step: new CreateAccount({name: 'create-account'}),
-            },
-          ], {
-            name: 'account-switch',
-          }),
-          new ParallelSteps([
-            new Flow([
-              new Download({name: 'download'}),
-              new RunKiteWithCopilot({name: 'launch-copilot'}),
-              new Authenticate({name: 'authenticate'}),
-              new InstallPlugin({name: 'install-plugin'}),
-            ], {name: 'download-flow'}),
-            new PassStep({
-              name: 'wait-step',
-              view: new InstallWaitElement('kite_installer_wait_step'),
-            }),
-          ], {
-            name: 'download-and-wait',
-          }),
-          new BranchStep([
-            {
-              match: (data) => !data.error,
-              step: new VoidStep({
-                name: 'end',
-                view: new InstallEndElement('kite_installer_install_end_step'),
-              }),
-            }, {
-              match: (data) => data.error,
-              step: new VoidStep({
-                name: 'error',
-                view: new InstallErrorElement('kite_installer_install_error_step'),
-              }),
-            },
-          ], {name: 'termination'}),
-        ];
-      },
-
-      autocompletePythonFlow: () => {
-        return [
-          new KiteVsJedi({
-            name: 'kite-vs-jedi',
-            view: new KiteVsJediElement('kite_installer_choose_kite_step'),
-          }),
-          new ParallelSteps([
-            new Flow([
-              new Download({name: 'download'}),
-              new InstallPlugin({name: 'install-plugin'}),
-              new RunKiteWithCopilot({name: 'launch-copilot'}),
-            ], {name: 'download-flow'}),
-            new PassStep({
-              name: 'wait-step',
-              view: new InstallWaitElement('kite_installer_wait_step'),
-            }),
-          ], {
-            name: 'download-and-wait',
-          }),
-          new BranchStep([
-            {
-              match: (data) => !data.error,
-              step: new VoidStep({
-                name: 'end',
-                view: new InstallEndElement('kite_installer_install_end_step'),
-              }),
-            }, 
-            {
-              match: (data) => data.error,
-              step: new VoidStep({
-                name: 'error',
-                view: new InstallErrorElement('kite_installer_install_error_step'),
-              }),
-            },
-          ], {name: 'termination'}),
-        ];
-      },
+      defaultFlow,
+      autocompletePythonFlow
     };
   },
 };

--- a/lib/install/void-step.js
+++ b/lib/install/void-step.js
@@ -9,6 +9,6 @@ module.exports = class VoidStep extends BaseStep {
   }
   start() {
     this.action && this.action();
-    return new Promise(() => {});
+    return Promise.resolve();
   }
 };


### PR DESCRIPTION
Original issue: https://github.com/kiteco/kiteco/issues/9172
Sibling PR: https://github.com/kiteco/atom-plugin/pull/650

Since there are two consumers of this repository (autocomplete-python and atom-plugin), one which uses webpack to bundle and the other that doesn't, I added a conditional that allows for both to work. I also removed the older defaultFlow that doesn't seem relevant anymore and replaced it with the second part of the flow ACP uses.